### PR TITLE
Better webaccess

### DIFF
--- a/plugins/clay_network/CMakeLists.txt
+++ b/plugins/clay_network/CMakeLists.txt
@@ -7,7 +7,7 @@ clay_p( Network
     SOURCES
         claynetworknode.cpp claywebaccess.cpp connection.cpp peermanager.cpp server.cpp
     QML_FILES
-        ClayNetworkUser.qml ClayHttpClient.qml Sandbox.qml
+        ClayNetworkUser.qml ClayHttpClient.qml Sandbox.qml SandboxHttpClient.qml
     LINK_LIBS
         Qt::Core Qt::Quick Qt::Qml Qt::Network
 )

--- a/plugins/clay_network/CMakeLists.txt
+++ b/plugins/clay_network/CMakeLists.txt
@@ -7,7 +7,7 @@ clay_p( Network
     SOURCES
         claynetworknode.cpp claywebaccess.cpp connection.cpp peermanager.cpp server.cpp
     QML_FILES
-        ClayNetworkUser.qml Sandbox.qml
+        ClayNetworkUser.qml ClayHttpClient.qml Sandbox.qml
     LINK_LIBS
         Qt::Core Qt::Quick Qt::Qml Qt::Network
 )

--- a/plugins/clay_network/ClayHttpClient.qml
+++ b/plugins/clay_network/ClayHttpClient.qml
@@ -1,0 +1,51 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+
+import QtQuick
+import Clayground.Network
+
+Item {
+    id: _clayHttpClient
+
+    property string baseUrl: ""
+    property var endpoints: ({})
+    property var service: ({})
+
+    signal reply(int requestId, int returnCode, string text);
+    signal error(int requestId, int returnCode, string text);
+
+    onBaseUrlChanged: _updateServiceAccess()
+    onEndpointsChanged: _updateServiceAccess()
+
+    ClayWebAccess {
+        id: _webAccess
+        onReply:  (reqId, returnCode, result) => {
+                      _clayHttpClient.reply(reqId, returnCode, result)
+                  }
+        onError:  (reqId, returnCode, result) => {
+                      _clayHttpClient.error(reqId, returnCode, result)
+                  }
+    }
+
+    function _updateServiceAccess() {
+        service = {};
+        for (const [endpoint, config] of Object.entries(endpoints)) {
+            service[endpoint] = (...args) => {
+                const buildPath = (template, params) => {
+                    let index = 0;
+                    return template.replace(/{\w+}/g, () => params[index++] || '');
+                };
+                const data = config.type === 'postJson' ? args.shift() : null;
+                const url = this.baseUrl + '/' + buildPath(config.path, args);
+                switch (config.type) {
+                    case 'get':
+                        return _webAccess.get(url);
+                    case 'postJson':
+                        return _webAccess.postJson(url, JSON.stringify(data));
+                    default:
+                        console.log(`Method '${config.type}' not supported.`);
+                }
+            };
+        }
+    }
+
+}

--- a/plugins/clay_network/ClayHttpClient.qml
+++ b/plugins/clay_network/ClayHttpClient.qml
@@ -85,6 +85,8 @@ Item {
                             return _webAccess.get(url, authString);
                         case "POST":
                             var json = jsonName !== "" && args.length ? args[args.length - 1] : "";
+                            if (typeof json == "object" && json !== null && !Array.isArray(json))
+                                json = JSON.stringify(json);
                             return _webAccess.post(url, json, authString);
                     }
                 }

--- a/plugins/clay_network/ClayHttpClient.qml
+++ b/plugins/clay_network/ClayHttpClient.qml
@@ -3,15 +3,45 @@
 import QtQuick
 import Clayground.Network
 
+// Component that generates an easy to use API based on provided
+// endpoint and authorization configuration.
 Item {
     id: _clayHttpClient
 
-    property string baseUrl: ""
-    property var endpoints: ({})
-    property var service: ({})
+    // END POINT CONFIGURATION
 
+    // There is only one base URL per client
+    // this allows keeping the (relative) URLs in the endpoints short
+    // Example: https://acme.com/products
+    property string baseUrl: ""
+
+    // Endpoints, each entry with the following structure:
+    // {HTTP_METHOD} {urlWithPathAndQueryParams} [{nameOfJsonBody}]
+    // Example: GET flyingObjects/{type} {aerodynamicRequirements}
+    // This will generate a method with client.api.flyingObjects("ufo", "{friction: low}"}
+    property var endpoints: ({})
+
+    // Object which contains all the methods based on the baseUrl and
+    // end point configuration.
+    property var api: ({})
+
+
+    // AUTHENTICATION/AUTHORIZATION
+    // TODO Add support for basic auth and API keys
+
+    // When using Bearer Authentication
+    // Syntax: {token}
+    property string bearerToken: ""
+
+
+    // RESULT REPORTING
+
+    // method has been executed successfully
     signal reply(int requestId, int returnCode, string text);
+
+    // an error happened during execution
     signal error(int requestId, int returnCode, string text);
+
 
     onBaseUrlChanged: _updateServiceAccess()
     onEndpointsChanged: _updateServiceAccess()
@@ -27,22 +57,38 @@ Item {
     }
 
     function _updateServiceAccess() {
-        service = {};
-        for (const [endpoint, config] of Object.entries(endpoints)) {
-            accessor[endpoint] = function(...params) {
-                let url = endpoints[endpoint];
-                const placeholders = url.match(/\{[^\}]+\}/g);
+        _clayHttpClient.api = {};
 
-                if (placeholders) {
-                    for (const placeholder of placeholders) {
-                        const param = params.shift();
-                        url = url.replace(placeholder, encodeURIComponent(param));
+        var authString = "";
+        if (_clayHttpClient.bearerToken !== "") {
+            authString = "Bearer " + _clayHttpClient.bearerToken;
+        }
+
+        for (var endpoint in _clayHttpClient.endpoints) {
+            var parts = _clayHttpClient.endpoints[endpoint].split(' ');
+            var httpMethod = parts[0].toUpperCase();
+            var endpointUrl = parts[1];
+            var jsonName = parts.length > 2 ? parts[2] : "";
+
+            // Ensure that every function has its relevant argument
+            // values otherwise all would just reference the last
+            // values of endpointUrl, httpMethod and jsonName
+            (function(endpointUrl, httpMethod, jsonName) {
+                _clayHttpClient.api[endpoint] = function() {
+                    var url = _clayHttpClient.baseUrl + "/" + endpointUrl;
+                    var args = Array.prototype.slice.call(arguments);
+                    url = url.replace(/\{.*?\}/g, function() {
+                        return args.shift();
+                    });
+                    switch (httpMethod) {
+                        case "GET":
+                            return _webAccess.get(url, authString);
+                        case "POST":
+                            var json = jsonName !== "" && args.length ? args[args.length - 1] : "";
+                            return _webAccess.post(url, json, authString);
                     }
                 }
-                const [method, path] = url.split(' ', 2);
-                const body = params.length > 0 ? JSON.stringify(params[0]) : null;
-            }
+            })(endpointUrl, httpMethod, jsonName);
         }
     }
-
 }

--- a/plugins/clay_network/SandboxHttpClient.qml
+++ b/plugins/clay_network/SandboxHttpClient.qml
@@ -1,41 +1,128 @@
 // (c) Clayground Contributors - MIT License, see "LICENSE" file
 
 import QtQuick
+import QtQuick.Controls
 import Clayground.Network
 
 Rectangle {
     anchors.fill: parent
     color: "black"
 
+    ClayHttpClient
+    {
+        id: openAi
+
+        baseUrl: "https://api.openai.com"
+        endpoints:  ({
+                         complete: "POST v1/chat/completions {chat}"
+                     })
+        // TODO: Change path to a file which contains the API key
+        // or put env.{my-variable-name} if it should be read from a
+        // env variable
+        bearerToken: "file:///path/to/bearer_token.txt"
+
+        onReply: (requestId, returnCode, text) => {
+                     const reply = JSON.parse(text);
+                     text = reply.choices[0].message.content;
+                     messageModel.append({"source": "ChatAi", "message": text});
+                 }
+        onError: (requestId, returnCode, text) => {txt.text = text; }
+
+        function complete(message)
+        {
+            let client = openAi.api;
+            const requestObj = {
+                model: "gpt-3.5-turbo",
+                messages: [{
+                        role: "user",
+                        content: message
+                    }]
+            };
+            let requestId = client.complete(requestObj);
+        }
+
+        Component.onCompleted: {
+            // TODO: Activate if you want to see the chat API
+            //       in action, don't forget to reference a valid
+            //       Bearer token.
+            // complete("What is the meaning of life?");
+        }
+    }
+
+    ClayHttpClient
+    {
+        id: jsonPlaceholder
+
+        baseUrl: "https://jsonplaceholder.typicode.com"
+        endpoints:  ({
+                         pubPost: "POST posts {data}",
+                         getPost: "GET posts/{postId}"
+                     })
+
+        onReply: (requestId, returnCode, text) => {txt.text = text; }
+        onError: (requestId, returnCode, text) => {txt.text = text; }
+
+        function demo() {
+            let client = jsonPlaceholder.api;
+            let requestId = client.pubPost(JSON.stringify({"hohoh": "world"}));
+            //Hint: There are already 100 posts, 101 is the newly added one
+            requestId = client.getPost(101);
+        }
+
+        Component.onCompleted: {
+            // TODO: Uncomment to see the placeholder api in action
+            // demo()
+        }
+    }
+
+    ListView {
+        id: messageList
+        anchors.fill: parent
+        anchors.margins: 10
+        anchors.bottomMargin: 50
+
+        model: ListModel {
+            id: messageModel
+        }
+
+        delegate: Rectangle {
+                    width: messageList.width
+                    height: messageText.implicitHeight + 10
+                    color: index % 2 === 0 ? "#303030" : "#4d4d4d"
+
+                    Text {
+                        id: messageText
+                        color: "white"
+                        width: parent.width - 10
+                        anchors.centerIn: parent
+                        text: model.source + ": " + model.message
+                        wrapMode: Text.Wrap
+                    }
+                }
+    }
+
+    TextField {
+        id: messageField
+        anchors.bottom: parent.bottom
+        width: parent.width
+        placeholderText: "Enter message"
+        color: "white"
+
+        onAccepted: {
+            messageModel.append({"source": "You", "message": text});
+            openAi.complete(text);
+            text = "";
+            messageList.positionViewAtEnd();
+        }
+    }
+
     Text {
         id: txt
-
         width: parent.width * .75
         wrapMode: Text.WordWrap
         anchors.centerIn: parent
         color: "white"
         font.family: "Monospace"
-
-        ClayHttpClient
-        {
-            id: jsonPlaceholder
-
-            baseUrl: "https://jsonplaceholder.typicode.com"
-            endpoints:  ({
-                             pubPost: "POST posts {data}",
-                             getPost: "GET posts/{postId}"
-                         })
-            onReply: (requestId, returnCode, text) => {console.log("SUCC " + text); txt.text = text; }
-            onError: (requestId, returnCode, text) => {console.log("ERR " + text); txt.text = text; }
-        }
-
-        Component.onCompleted: {
-            let client = jsonPlaceholder.api;
-            let requestId = client.pubPost(JSON.stringify({"hohoh": "world"}));
-            //Hint: There are already 100 posts, 101 is the newly added one
-            requestId = client.getPost(101)
-
-        }
     }
 
 }

--- a/plugins/clay_network/SandboxHttpClient.qml
+++ b/plugins/clay_network/SandboxHttpClient.qml
@@ -20,8 +20,10 @@ Rectangle {
         {
             id: restClient
             baseUrl: "https://jsonplaceholder.typicode.com"
+            apiToken: "ENV.MY_API_TOKEN"
             endpoints:  ({
-                             posts: {type: 'get', path: "posts/{postId}", json: false}
+                             user: "GET users/{groupId}?id={userid}",
+                             news: "POST news/{category} {news_as_json}"
                          })
             onReply: (requestId, returnCode, text) => {
                          txt.text = text;

--- a/plugins/clay_network/SandboxHttpClient.qml
+++ b/plugins/clay_network/SandboxHttpClient.qml
@@ -18,25 +18,23 @@ Rectangle {
 
         ClayHttpClient
         {
-            id: restClient
+            id: jsonPlaceholder
+
             baseUrl: "https://jsonplaceholder.typicode.com"
-            apiToken: "ENV.MY_API_TOKEN"
             endpoints:  ({
-                             user: "GET users/{groupId}?id={userid}",
-                             news: "POST news/{category} {news_as_json}"
+                             pubPost: "POST posts {data}",
+                             getPost: "GET posts/{postId}"
                          })
-            onReply: (requestId, returnCode, text) => {
-                         txt.text = text;
-                         console.log(text)
-                     }
-            onError: (requestId, returnCode, text) => {
-                         txt.text = text;
-                     }
+            onReply: (requestId, returnCode, text) => {console.log("SUCC " + text); txt.text = text; }
+            onError: (requestId, returnCode, text) => {console.log("ERR " + text); txt.text = text; }
         }
 
         Component.onCompleted: {
-            let client = restClient.service;
-            client.posts(4)
+            let client = jsonPlaceholder.api;
+            let requestId = client.pubPost(JSON.stringify({"hohoh": "world"}));
+            //Hint: There are already 100 posts, 101 is the newly added one
+            requestId = client.getPost(101)
+
         }
     }
 

--- a/plugins/clay_network/SandboxHttpClient.qml
+++ b/plugins/clay_network/SandboxHttpClient.qml
@@ -1,0 +1,41 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+
+import QtQuick
+import Clayground.Network
+
+Rectangle {
+    anchors.fill: parent
+    color: "black"
+
+    Text {
+        id: txt
+
+        width: parent.width * .75
+        wrapMode: Text.WordWrap
+        anchors.centerIn: parent
+        color: "white"
+        font.family: "Monospace"
+
+        ClayHttpClient
+        {
+            id: restClient
+            baseUrl: "https://jsonplaceholder.typicode.com"
+            endpoints:  ({
+                             posts: {type: 'get', path: "posts/{postId}", json: false}
+                         })
+            onReply: (requestId, returnCode, text) => {
+                         txt.text = text;
+                         console.log(text)
+                     }
+            onError: (requestId, returnCode, text) => {
+                         txt.text = text;
+                     }
+        }
+
+        Component.onCompleted: {
+            let client = restClient.service;
+            client.posts(4)
+        }
+    }
+
+}

--- a/plugins/clay_network/claynetworknode.cpp
+++ b/plugins/clay_network/claynetworknode.cpp
@@ -1,3 +1,4 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
 #include <QtNetwork>
 
 #include "claynetworknode.h"

--- a/plugins/clay_network/claywebaccess.cpp
+++ b/plugins/clay_network/claywebaccess.cpp
@@ -93,7 +93,7 @@ int ClayWebAccess::sendRequest(QNetworkAccessManager::Operation operation,
                                const QByteArray &data,
                                const QString &contentType)
 {
-    auto req = QNetworkRequest(url);
+    auto req = QNetworkRequest(QUrl(url));
     req.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
     if (!contentType.isEmpty())
         req.setHeader(QNetworkRequest::ContentTypeHeader, contentType);
@@ -110,14 +110,6 @@ int ClayWebAccess::sendRequest(QNetworkAccessManager::Operation operation,
         else {
             qWarning() << "Skipping unsupported auth type: " << authString;
         }
-    }
-
-    qDebug() << "Request URL:" << req.url().toString();
-
-    QList<QByteArray> headers = req.rawHeaderList();
-    qDebug() << "Request Headers:";
-    foreach (const QByteArray& header, headers) {
-        qDebug() << header << ":" << req.rawHeader(header);
     }
 
     QNetworkReply *reply = nullptr;

--- a/plugins/clay_network/claywebaccess.h
+++ b/plugins/clay_network/claywebaccess.h
@@ -4,22 +4,42 @@
 #include <QObject>
 #include <QString>
 #include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QMap>
+#include <QQmlComponent>
 
 class ClayWebAccess : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     ClayWebAccess(QObject* parent = nullptr);
 
 public slots:
     int get(const QString& url);
+    int postJson(const QString& url, const QString& jsonData);
+    int putJson(const QString& url, const QString& jsonData);
+    int postBinary(const QString& url,
+                   const QByteArray& data,
+                   const QString& contentType = "");
+    int putBinary(const QString& url,
+                  const QByteArray& data,
+                   const QString& contentType = "");
     void onFinished(QNetworkReply *networkReply);
 
+private:
+    int sendRequest(QNetworkAccessManager::Operation operation,
+                    const QString &url,
+                    const QByteArray &data = QByteArray(),
+                    const QString &contentType = "");
+
 signals:
-    void reply(const QString& text);
-    void error(const QString& text);
+    void reply(int requestId, int returnCode, const QString& text);
+    void error(int requestId, int returnCode, const QString& text);
 
 private:
     QNetworkAccessManager networkManager_;
+    QMap<int, QNetworkReply*> pendingRequests_;
+    int nextRequestId_ = 1;
 };

--- a/plugins/clay_network/claywebaccess.h
+++ b/plugins/clay_network/claywebaccess.h
@@ -1,4 +1,5 @@
-// (c) serein.pfeiffer@gmail.com - zlib license, see "LICENSE" file
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+
 #pragma once
 
 #include <QObject>
@@ -8,6 +9,11 @@
 #include <QMap>
 #include <QQmlComponent>
 
+/**
+ *  Class for accessing HTTP APIs.
+ *  Likely to be replaced by one already available solution which is
+ *  more mature.
+ */
 class ClayWebAccess : public QObject
 {
     Q_OBJECT
@@ -17,27 +23,32 @@ public:
     ClayWebAccess(QObject* parent = nullptr);
 
 public slots:
-    int get(const QString& url);
-    int postJson(const QString& url, const QString& jsonData);
-    int putJson(const QString& url, const QString& jsonData);
-    int postBinary(const QString& url,
-                   const QByteArray& data,
-                   const QString& contentType = "");
-    int putBinary(const QString& url,
-                  const QByteArray& data,
-                   const QString& contentType = "");
+    /** Performs an HTTP GET request, returns a unique request ID. */
+    int get(const QString& url, const QString& auth = "");
+
+    /** Performs an HTTP POST request, returns a unique request ID. */
+    int post(const QString& url, const QString& json, const QString& auth = "");
+
+signals:
+    /** Signal emitted when a request is successfully processed. */
+    void reply(int requestId, int returnCode, const QString& text);
+
+    /** Signal emitted when a request encounters an error. */
+    void error(int requestId, int returnCode, const QString& text);
+
+private slots:
     void onFinished(QNetworkReply *networkReply);
 
 private:
+    QString resolveAuthString(const QString &authStr);
+    int remPendingRequest(QNetworkReply *reply);
+    void handleNetworkError(QNetworkReply *reply, const QString &errorDetails);
     int sendRequest(QNetworkAccessManager::Operation operation,
                     const QString &url,
+                    const QString &authString = "",
                     const QByteArray &data = QByteArray(),
-                    const QString &contentType = "",
-                    const QString &authString = "");
-
-signals:
-    void reply(int requestId, int returnCode, const QString& text);
-    void error(int requestId, int returnCode, const QString& text);
+                    const QString &contentType = ""
+                    );
 
 private:
     QNetworkAccessManager networkManager_;

--- a/plugins/clay_network/claywebaccess.h
+++ b/plugins/clay_network/claywebaccess.h
@@ -32,7 +32,8 @@ private:
     int sendRequest(QNetworkAccessManager::Operation operation,
                     const QString &url,
                     const QByteArray &data = QByteArray(),
-                    const QString &contentType = "");
+                    const QString &contentType = "",
+                    const QString &authString = "");
 
 signals:
     void reply(int requestId, int returnCode, const QString& text);


### PR DESCRIPTION
- Refines C++ web access class to focus on GET, POST with bearerToken as the only supported auth method at the moment
- Introduces ClayHttpClient.qml which is a convenience wrapper for the C++ web access, it supports declaring HTTP APIs and generates JavaScript client object that can be used to access them
- Introduces a dedicated web access sandbox that demonstrates accessing a HTTP test service as well as OpenAI's chat (which also requires specification of a bearer token)