### PR TITLE
ci: fix docs-rebuild trigger on release

### DIFF
--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -133,4 +133,4 @@ jobs:
       - name: Trigger docs rebuild to include release WASM on Pages
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run docs-check.yml --ref main
+        run: gh workflow run docs-check.yml --repo "$GITHUB_REPOSITORY" --ref main


### PR DESCRIPTION
The `trigger-docs-rebuild` job runs `gh workflow run` without checking out the repo, so `gh` fails with "not a git repository" - this broke the final release job on both v2026.2 and v2026.3. Passing `--repo` explicitly lets `gh` resolve the workflow without a local checkout.