### PR TITLE
webdojo: resolve new releases as latest immediately

### DIFF
--- a/docs/assets/js/webdojo-loader.js
+++ b/docs/assets/js/webdojo-loader.js
@@ -65,7 +65,7 @@
 
         if (version === 'latest') {
             // Fetch versions manifest to resolve latest tag
-            return fetch(baseUrl + '/v/versions.json')
+            return fetch(baseUrl + '/v/versions.json', { cache: 'no-store' })
                 .then(function(r) { return r.ok ? r.json() : Promise.reject(); })
                 .then(function(data) {
                     if (data.latest) {

--- a/docs/assets/js/webdojo.js
+++ b/docs/assets/js/webdojo.js
@@ -87,7 +87,7 @@ async function resolveVersion(version) {
         // Try same-origin versions manifest first, fall back to GitHub API
         const baseUrl = document.querySelector('meta[name="baseurl"]')?.content || '';
         try {
-            const mResp = await fetch(`${baseUrl}/v/versions.json`);
+            const mResp = await fetch(`${baseUrl}/v/versions.json`, { cache: 'no-store' });
             if (mResp.ok) {
                 const data = await mResp.json();
                 if (data.latest) {
@@ -134,7 +134,7 @@ async function fetchAvailableVersions() {
     // Try same-origin versions manifest first (no rate limits, faster)
     const baseUrl = document.querySelector('meta[name="baseurl"]')?.content || '';
     try {
-        const mResp = await fetch(`${baseUrl}/v/versions.json`);
+        const mResp = await fetch(`${baseUrl}/v/versions.json`, { cache: 'no-store' });
         if (mResp.ok) {
             const data = await mResp.json();
             if (data.versions && data.versions.length > 0) {


### PR DESCRIPTION
versions.json was fetched with default caching (GitHub Pages serves it with max-age=600), so for up to 10 minutes after a release visitors still resolved the previous latest - whose release has no starter bundle, making the Export site button error unless dev was selected. Fetching the 58-byte manifest with cache: 'no-store' removes the window.