### PR TITLE
Speed up CI with compiler + Qt caching (#148)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -78,10 +78,17 @@ jobs:
           bundler-cache: true
           working-directory: ./docs
 
+      - name: Setup compiler cache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          variant: ccache
+          key: docs-website
+          max-size: 1G
+
       - name: Configure CMake
         run: |
           # QT_HOST_PATH points to desktop Qt for host tools like QDoc
-          "$QT_ROOT_DIR/bin/qt-cmake" -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCLAY_BUILD_WEBSITE=ON -DQT_HOST_PATH="${{ runner.temp }}/qt-desktop/Qt/${{ env.QT_VERSION_HOST }}/gcc_64" .
+          "$QT_ROOT_DIR/bin/qt-cmake" -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCLAY_BUILD_WEBSITE=ON -DQT_HOST_PATH="${{ runner.temp }}/qt-desktop/Qt/${{ env.QT_VERSION_HOST }}/gcc_64" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache .
 
       - name: Build Website
         run: cmake --build build --target website

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # Manual on-demand runs (e.g. to validate a PR into a release branch, which
+  # otherwise gets no CI) — kept opt-in to avoid burning runners on every PR.
+  workflow_dispatch:
 
 # Prevent multiple runs of the same workflow on the same ref
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
         arch: ${{ matrix.qt-arch }}
         modules: ${{ env.QT_MODULES }}
         aqtversion: ${{ env.AQT_VERSION }}
+        cache: true
 
     - name: Install Linux Dependencies
       if: runner.os == 'Linux' && matrix.qt-target == 'desktop'
@@ -84,15 +85,24 @@ jobs:
       if: runner.os == 'Windows' && matrix.qt-target == 'desktop'
       uses: ilammy/msvc-dev-cmd@v1
 
+    # ccache on Linux/WASM, sccache on Windows (better MSVC support).
+    # Wired into the build via CMAKE_<LANG>_COMPILER_LAUNCHER below.
+    - name: Setup compiler cache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        variant: ${{ runner.os == 'Windows' && 'sccache' || 'ccache' }}
+        key: ${{ matrix.os }}-${{ matrix.qt-target }}
+        max-size: 1G
+
     - name: Configure CMake (Desktop)
       if: matrix.qt-target == 'desktop'
       run: |
-        cmake -B build -GNinja -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DQT_QMAKE_EXECUTABLE=qmake ${{ runner.os == 'Windows' && '-DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl' || '' }} .
+        cmake -B build -GNinja -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DQT_QMAKE_EXECUTABLE=qmake ${{ runner.os == 'Windows' && '-DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl' || '' }} -DCMAKE_C_COMPILER_LAUNCHER=${{ runner.os == 'Windows' && 'sccache' || 'ccache' }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ runner.os == 'Windows' && 'sccache' || 'ccache' }} .
 
     - name: Configure CMake (WASM)
       if: matrix.qt-target == 'wasm'
       run: |
-        "$QT_ROOT_DIR/bin/qt-cmake" -B build -GNinja -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} .
+        "$QT_ROOT_DIR/bin/qt-cmake" -B build -GNinja -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache .
 
     - name: Build (Desktop)
       if: matrix.qt-target == 'desktop'
@@ -110,11 +120,13 @@ jobs:
         WASM=build/bin/clayground.wasm
         RAW=$(stat -c%s "$WASM")
         GZ=$(gzip -9 -c "$WASM" | wc -c)
-        BR=$(brotli -q 11 -c "$WASM" | wc -c)
+        # -q9 instead of -q11: nearly identical ratio for a size estimate, but
+        # seconds instead of ~90s on a ~30 MB wasm. The gate below is on raw size.
+        BR=$(brotli -q 9 -c "$WASM" | wc -c)
         mb() { echo "$1" | awk '{printf "%.1f", $1/1048576}'; }
         {
           echo "### Clayground Web Runtime size"
-          echo "| raw | gzip -9 | brotli -q11 |"
+          echo "| raw | gzip -9 | brotli -q9 |"
           echo "|---|---|---|"
           echo "| $(mb "$RAW") MB | $(mb "$GZ") MB | $(mb "$BR") MB |"
         } >> "$GITHUB_STEP_SUMMARY"

--- a/tools/webdojo/tests/wasm_smoke_test.py
+++ b/tools/webdojo/tests/wasm_smoke_test.py
@@ -65,7 +65,6 @@ def main():
 
     booted = qml_loaded = False
     errors = []
-    settled = threading.Event()
 
     with sync_playwright() as p:
         browser = launch_browser(p)
@@ -85,13 +84,18 @@ def main():
                 qml_loaded = True
             if any(marker in text for marker in ERROR_MARKERS):
                 errors.append(text)
-            if qml_loaded or errors:
-                settled.set()
 
         page.on("console", on_console)
-        page.on("pageerror", lambda e: (errors.append(f"pageerror: {e}"), settled.set()))
+        page.on("pageerror", lambda e: errors.append(f"pageerror: {e}"))
         page.goto(url)
-        settled.wait(args.timeout)
+        # Poll via a Playwright call so the sync event loop is pumped and console
+        # events actually fire; a bare threading.Event.wait() would stall dispatch
+        # and always burn the full timeout even when the app boots in seconds.
+        waited = 0
+        deadline_ms = args.timeout * 1000
+        while waited < deadline_ms and not (qml_loaded or errors):
+            page.wait_for_timeout(250)
+            waited += 250
         page.wait_for_timeout(1500)  # let trailing errors and rendering arrive
         if args.screenshot:
             page.screenshot(path=args.screenshot)


### PR DESCRIPTION
Cuts CI wall-clock and runner-minutes by caching the parts that were recompiled/redownloaded from scratch on every run, and by fixing a smoke test that always burned its full timeout. Closes #148.

The four heavy build steps (5–7.5 min each) dominated a ~13 min gating path with no compiler cache anywhere; on warm caches they should drop to roughly 1–2 min.

**Caching**
- Add `ccache` (Linux/WASM) and `sccache` (Windows) via `hendrikmuhs/ccache-action`, wired through `CMAKE_<LANG>_COMPILER_LAUNCHER`, across the CI matrix and the Documentation website build
- Enable Qt install caching in `main.yml` (`cache: true`), matching `docs-check.yml`
- Drop the WASM size-report `brotli` from `-q11` to `-q9` (~90s → seconds; the soft budget gate is on raw size, so the number stays representative)

**WASM smoke test (`wasm_smoke_test.py`)**
- The test waited on a `threading.Event` that was only set from a sync-Playwright console callback. That callback only fires while the main thread is inside a Playwright call, so the bare `Event.wait()` never got pumped and always blocked the full 180s — even though the app boots in seconds (it passed because the queued events drained during the trailing 1.5s wait). Replaced with a poll that pumps the event loop, so the step exits at real boot time (~3:20 → ~30s) and a genuinely slow boot is now actually observable instead of hidden under the blanket wait.

**On-demand runs**
- Add `workflow_dispatch` to the CI workflow so it can be triggered manually (e.g. to validate a PR into a release branch, which otherwise gets no CI) while keeping automatic runs opt-in to save runners

Notes:
- `workflow_dispatch` only becomes usable once this lands on the default branch (GitHub only dispatches workflows present on `main`), so it cannot retroactively validate this PR.
- First run on each cache key is still cold (it populates the cache); the build speedup shows from the second run onward.