### PR TITLE
clayrender returns eval values and starts paused; Lab.runFlow() walks a flow headless

### DIFF
--- a/docs/docs/manual/clayrender.md
+++ b/docs/docs/manual/clayrender.md
@@ -65,6 +65,80 @@ that was never reached is worse than no picture. A *broken* expression is a
 different thing: that is exit 1 with the QML error, so a typo never reads as
 "the state never happened".
 
+## Getting an answer back
+
+`--eval` and `--script` change the scene; `--result` says what they came out
+to. It writes a JSON array with one entry per fragment, in the order they ran:
+
+```bash
+clayrender labs/electronics-101/Sandbox.qml --out board.png --paused \
+    --result - --eval 'Lab.scenario' --eval 'toggleSwitch(2); return simOf(4).i'
+```
+
+```json
+[
+    { "source": "Lab.scenario", "value": "led-basic" },
+    { "source": "toggleSwitch(2); return simOf(4).i", "value": 0.005149224103621227 }
+]
+```
+
+`-` means stdout; anything else is a file. `source` is the fragment as the
+command line spelled it — for `--script`, the path.
+
+A fragment that parses as an *expression* answers with what it evaluates to,
+so `clock.time` is a number rather than `null`. A fragment of several
+statements answers with what it `return`s, and with `null` when it returns
+nothing. A value JSON cannot carry — a QML object, a function, `NaN` — comes
+back as its `String()`, because an unreadable answer is worse than an
+approximate one.
+
+Values are captured **where the fragment runs**, which is before `--wait-for`,
+before `--settle` and before the capture. An `--eval` written after
+`--wait-for` on the command line still runs first, so it reports the state
+*before* the wait; put the assertion in the `--wait-for` expression instead and
+read the exit code.
+
+## Starting paused
+
+`--paused` sets `Clayground.paused` before the sandbox root is created, so no
+frame ticker ever starts:
+
+```bash
+clayrender labs/sensor-fusion-101/Sandbox.qml --out shot.png \
+    --paused --result - --eval 'clock.time'      # 0, not "some wall clock"
+```
+
+Without it, the frames rendered at load have already moved sim time by the
+first `--eval` — which is why recipes used to open with
+`clock._frameTicker.running = false`, and why one that forgot produced a
+different number on every machine. A stepped run advances the clock itself
+(`Lab.runFlow()`, `clock._advance(1 / 60)`), and `--paused` is what stops
+anything else from advancing it underneath.
+
+## Running a lab's flow
+
+`Lab.runFlow(flowId)` walks a lab's guided flow with nobody watching and
+reports what broke — the headless half of *every flow is also a test*:
+
+```bash
+clayrender labs/electronics-101/Sandbox.qml --out /tmp/x.png \
+    --paused --result - --eval 'Lab.runFlow("led-basics")'
+```
+
+```json
+{ "flowId": "led-basics", "steps": 5292, "finished": true,
+  "unresolvedVerbs": [], "failedTasks": [], "failedExpects": [] }
+```
+
+It forces `pacing: "auto"`, advances the clock in 1/60 s steps and performs
+every learner task itself, so a whole lesson runs in a second or two. A verb
+the lab does not have lands in `unresolvedVerbs` (a missing verb otherwise
+fails silently), a `FlowStep.expect` that does not hold lands in
+`failedExpects` with its step key, and `finished: false` means the step bound
+was hit rather than the end — never a hang. While it runs, `Lab.headless` is
+set: the narrator hides, the professor stays put and no narration audio is
+decoded.
+
 ## Getting a usable image
 
 | Option | Effect |

--- a/labs/kits/professor/FlowGuide.qml
+++ b/labs/kits/professor/FlowGuide.qml
@@ -20,6 +20,7 @@
 
 import QtQuick
 import Clayground.Character3D
+import Clayground.Lab
 
 Item {
     id: root
@@ -187,7 +188,10 @@ Item {
     // --- what happens when ----------------------------------------------------
 
     onRunningChanged: {
-        if (!root.professor)
+        // Lab.headless is a run with no audience: no arrival, no flight, no
+        // narration clip. The professor is the slowest thing in a lesson and
+        // none of it is state the flow's own checks look at.
+        if (!root.professor || Lab.headless)
             return
         if (root.running) {
             if (root.entrance)
@@ -219,7 +223,7 @@ Item {
 
     function _go() {
         const p = root.professor
-        if (!p || !root.running || root.step < 0)
+        if (!p || !root.running || root.step < 0 || Lab.headless)
             return
 
         const s = (typeof root.subjectOf === "function") ? root.subjectOf(root.step) : null
@@ -380,7 +384,7 @@ Item {
     // one moment the professor is deliberately silent, and arriving speaks the
     // current text anyway.
     onTextChanged: {
-        if (!root.running || root.step < 0)
+        if (!root.running || root.step < 0 || Lab.headless)
             return
         if (root.professor && root.professor.travelling)
             return

--- a/labs/kits/professor/Professor.qml
+++ b/labs/kits/professor/Professor.qml
@@ -529,7 +529,12 @@ Node {
     */
     function tell(what, clip) {
         root.line = what
-        const url = (clip === undefined || clip === null) ? "" : "" + clip
+        // A headless run has no ears. Assigning the source is what starts the
+        // decode - Qt Multimedia's ffmpeg plugin loads the file on a worker
+        // thread - so a check that walks a narrated flow pays for every clip
+        // it will never play (#207).
+        const url = (clip === undefined || clip === null || Lab.headless)
+                    ? "" : "" + clip
         _voice.stop()
         _voice.source = url
         _talking = (what !== undefined && what !== "")
@@ -650,6 +655,9 @@ Node {
     function say(what) {
         root.line = what
         _char.speechBodyLanguage = false
+        // Same as tell(): nobody is listening, and the speech engine is the
+        // one part of a lesson that cannot be stepped in sim time.
+        if (Lab.headless) { _talking = false; return }
         _talking = true
         _saying = true
         _sayStarted = false

--- a/plugins/clay_lab/Flow.qml
+++ b/plugins/clay_lab/Flow.qml
@@ -108,6 +108,20 @@ Item {
     property bool hintShown: false
 
     /*!
+        \qmlproperty var Flow::unresolvedVerbs
+        \readonly
+        \brief Verb names a demo or a solve asked for and the lab does not have.
+
+        Cleared by \l start(). A verb that does not resolve fails SILENTLY -
+        the action does nothing and the flow walks on teaching nothing - so a
+        headless run has to be able to read the list rather than hope somebody
+        was watching the log.
+
+        \sa Lab::runFlow
+    */
+    property var unresolvedVerbs: []
+
+    /*!
         \qmlproperty string Flow::pacing
         \brief How a step ends: "ready" (default), "auto" or "manual".
 
@@ -188,6 +202,7 @@ Item {
     */
     function start() {
         _checkpoints = ({}); _names = ({})
+        unresolvedVerbs = []
         paused = false
         goTo(0)
     }
@@ -296,7 +311,11 @@ Item {
             let verb = a[0], args = a.slice(1), bind = null
             if (verb === "let") { bind = args[0]; verb = args[1]; args = args.slice(2) }
             const fn = vs[verb]
-            if (!fn) { console.warn("Flow: lab has no verb '" + verb + "'"); continue }
+            if (!fn) {
+                console.warn("Flow: lab has no verb '" + verb + "'")
+                unresolvedVerbs = unresolvedVerbs.concat([verb])
+                continue
+            }
             const out = fn.apply(null, args.map(x => nameOf(x)))
             if (bind !== null) _names[bind] = out
         }
@@ -309,6 +328,22 @@ Item {
         if (s.dwell !== "auto") return Number(s.dwell)
         const words = sayOf(s).split(/\s+/).length
         return Math.max(2.5, words / 2.2)
+    }
+
+    // Filed with the kernel so Lab.runFlow() can find it by id. Registration
+    // follows Parameter's rule - the moment the id is known, not at completion
+    // - because a lab's own Component.onCompleted runs before its children's.
+    Component.onCompleted: _register()
+    Component.onDestruction: Lab.unregisterFlow(_flow)
+    onFlowIdChanged: _register()
+
+    property string _registered: ""
+
+    function _register() {
+        if (flowId === _registered) return
+        if (_registered !== "") Lab.unregisterFlowNamed(_registered, _flow)
+        _registered = flowId
+        if (flowId !== "") Lab.registerFlow(_flow)
     }
 
     // Sim-time driven, never a wall clock: same states live and headless.

--- a/plugins/clay_lab/Lab.qml
+++ b/plugins/clay_lab/Lab.qml
@@ -60,8 +60,30 @@ QtObject {
     */
     signal sampled(real t)
 
+    /*!
+        \qmlproperty bool Lab::headless
+        \brief No one is watching: skip audio and character travel.
+
+        Set by \l runFlow() for the length of a headless run and restored
+        afterwards; a host may also set it by hand. What honours it is
+        deliberately small and listed here rather than guessed at: \l Narrator
+        hides, the professor kit's FlowGuide leaves the character where it is,
+        and pre-rendered narration is not loaded. Nothing about the SIMULATION
+        changes - a flow must traverse the same states headless as it does on
+        screen, or running it as a check proves nothing.
+    */
+    property bool headless: false
+
+    /*!
+        \qmlproperty var Lab::flowIds
+        \readonly
+        \brief Ids of all registered flows (registration order).
+    */
+    property var flowIds: []
+
     property var _params: ({})
     property var _probes: ({})
+    property var _flows: ({})
 
     function registerParameter(par) {
         if (!par.name) { console.warn("Lab: Parameter without name ignored"); return }
@@ -90,6 +112,23 @@ QtObject {
         if (_probes[probe.name] === probe) {
             delete _probes[probe.name]
             probeNames = Object.keys(_probes)
+        }
+    }
+
+    function registerFlow(flow) {
+        if (!flow.flowId) { console.warn("Lab: Flow without flowId ignored"); return }
+        _flows[flow.flowId] = flow
+        flowIds = Object.keys(_flows)
+    }
+
+    function unregisterFlow(flow) { unregisterFlowNamed(flow.flowId, flow) }
+
+    // Same story as Parameter: a Flow files itself as soon as its id arrives,
+    // so it also has to be able to withdraw the entry under a PREVIOUS id.
+    function unregisterFlowNamed(id, flow) {
+        if (_flows[id] === flow) {
+            delete _flows[id]
+            flowIds = Object.keys(_flows)
         }
     }
 
@@ -165,6 +204,138 @@ QtObject {
             params: params,
             probes: probeSummary()
         }
+    }
+
+    /*!
+        \qmlmethod var Lab::runFlow(string flowId, var opts)
+        \brief Runs a registered \l Flow to its end with nobody watching.
+
+        The headless half of "every flow is also a test": it starts the flow
+        through the lab's own \c startFlow() when the lab has one, forces
+        \c {pacing: "auto"}, advances \l clock in fixed 1/60 s steps and
+        performs every task itself with \c Flow::solve(). Nothing is waited
+        for in wall-clock time, so a whole lesson runs in well under a second.
+
+        Returns what broke rather than throwing:
+
+        \list
+        \li \c flowId, \c steps - the id asked for and how many 1/60 s steps it took;
+        \li \c unresolvedVerbs - verb names the flow asked the lab for and did
+            not get (a missing verb otherwise fails silently);
+        \li \c failedTasks - \c {{index, step}} for a task still unsatisfied
+            \c opts.solveGrace sim seconds after its own \c solve() ran;
+        \li \c failedExpects - \c {{index, step}} (plus \c error when the
+            predicate threw) for every \c FlowStep::expect that did not hold,
+            asserted the moment the flow leaves the step;
+        \li \c finished - the flow reached its end. False means the bound was
+            hit;
+        \li \c error - the run never started (no such flow, no clock).
+        \endlist
+
+        \c opts.maxSteps (default 20000, i.e. ~5.5 sim minutes) bounds the run
+        so a \c watch that never comes true is a false \c finished rather than
+        a hang. \c opts.solveGrace (default 5 sim seconds) is how long a task
+        gets after being solved before it counts as failed.
+
+        \l headless is true for the length of the run and restored afterwards.
+
+        \sa Flow, headless
+    */
+    function runFlow(flowId, opts) {
+        opts = opts ?? ({})
+        const maxSteps = opts.maxSteps !== undefined ? opts.maxSteps : 20000
+        const grace = Math.max(1, Math.round(
+            60 * (opts.solveGrace !== undefined ? opts.solveGrace : 5)))
+        const r = { flowId: flowId, steps: 0, unresolvedVerbs: [],
+                    failedTasks: [], failedExpects: [], finished: false }
+
+        const f = _flows[flowId]
+        if (!f) {
+            r.error = "no flow '" + flowId + "'; registered: [" + flowIds.join(", ") + "]"
+            return r
+        }
+        if (!clock) {
+            r.error = "no SimClock: a flow is driven in sim time, not in frames"
+            return r
+        }
+
+        const wasHeadless = headless
+        const wasPacing = f.pacing
+        headless = true
+        f.pacing = "auto"
+
+        // A step's expect is asserted the moment the flow LEAVES the step.
+        // Flow.goTo() assigns index BEFORE it runs the next step's demo, so
+        // this handler is the last instant at which the lab still holds the
+        // state the finished step produced - checking after the loop noticed
+        // would assert it against the next step's setup.
+        let at = -1
+        let asserting = true
+        const onIndex = function() {
+            if (!asserting) return
+            if (at >= 0) _assertExpect(f, at, r)
+            at = f.index
+        }
+        f.indexChanged.connect(onIndex)
+
+        try {
+            const root = f.lab
+            if (root && typeof root.startFlow === "function") root.startFlow(flowId)
+            if (!f.running) f.start()      // no entry point, or it refused
+            if (!f.running) {
+                r.error = "the flow did not start"
+                return r
+            }
+
+            let solvedAt = -1
+            let solvedStep = 0
+            while (f.running && r.steps < maxSteps) {
+                const i = f.index
+                if (f.waiting) {
+                    if (solvedAt !== i) { solvedAt = i; solvedStep = r.steps; f.solve() }
+                    else if (r.steps - solvedStep > grace) {
+                        // Solved and still not satisfied: report it and walk
+                        // on, so one broken task does not eat the whole budget
+                        // and hide every step after it.
+                        r.failedTasks.push({ index: i, step: _stepKey(f, i) })
+                        asserting = false
+                        f.next()
+                        asserting = true
+                        at = f.index
+                        continue
+                    }
+                }
+                clock._advance(1 / 60)
+                r.steps += 1
+            }
+            r.finished = !f.running
+        } finally {
+            asserting = false
+            f.indexChanged.disconnect(onIndex)
+            if (f.running) f.stop()
+            f.pacing = wasPacing
+            headless = wasHeadless
+            r.unresolvedVerbs = (f.unresolvedVerbs ?? []).slice()
+        }
+        return r
+    }
+
+    function _stepKey(f, i) {
+        const s = f.steps[i]
+        return s ? s.key : ""
+    }
+
+    function _assertExpect(f, i, r) {
+        const s = f.steps[i]
+        if (!s || !s.expect) return
+        let ok = false
+        let threw = ""
+        try { ok = !!s.expect(f.nameOf) }
+        catch (e) { threw = "" + e }
+        if (ok) return
+        const entry = { index: i, step: s.key }
+        if (threw !== "") entry.error = threw
+        r.failedExpects.push(entry)
     }
 
     /*!

--- a/plugins/clay_lab/Narrator.qml
+++ b/plugins/clay_lab/Narrator.qml
@@ -36,7 +36,10 @@ Rectangle {
     */
     property bool showText: true
 
-    visible: flow !== null && flow.running
+    // Lab.headless is a run with nobody in front of it: the panel would
+    // still animate its ripening Next control frame after frame for a
+    // reader who does not exist.
+    visible: flow !== null && flow.running && !Lab.headless
     implicitWidth: LabTheme.px(640)
     implicitHeight: _col.implicitHeight + 2 * LabTheme.spaceXl + LabTheme.spaceXs
     width: implicitWidth

--- a/plugins/clay_lab/tests/tst_flow.qml
+++ b/plugins/clay_lab/tests/tst_flow.qml
@@ -19,6 +19,14 @@ import Clayground.Lab
 Item {
     width: 50; height: 50
 
+    // A clock nothing drives but the test. SimClock's frame ticker is off
+    // whenever it has a world, and a world with no physics connects nothing -
+    // so sim time only moves where a test moves it. The alternative,
+    // Clayground.paused, is process-global and every tst_*.qml in this
+    // directory shares one runner.
+    QtObject { id: fakeWorld; property var physics: null }
+    SimClock { id: clock; world: fakeWorld; sampleInterval: 0.1 }
+
     // A lab just real enough to be driven: it hands out ids, it can be asked
     // what it looks like, and it can be put back.
     Item {
@@ -113,6 +121,57 @@ Item {
         FlowStep { key: "posed"; view: ({ pose: { yaw: 30 } }) }
     }
 
+    // --- the flows Lab.runFlow() is asked to walk --------------------------
+    // Short dwells throughout: the run is in sim seconds, and a reading
+    // estimate would only make the loop count bigger, never the check better.
+
+    Flow {
+        id: goodFlow
+        lab: fakeLab
+        flowId: "tst-good"
+
+        FlowStep { key: "intro"; dwell: 0.3; say: "nothing yet" }
+        FlowStep { key: "place"; dwell: 0.3; demo: [["let", "bat", "addPart", "battery"]] }
+        FlowStep {
+            key: "tag"
+            task: ({ "until": (n) => fakeLab.tagged === n("bat"),
+                     "solve": [["tagPart", "bat"]] })
+        }
+        FlowStep { key: "check"; dwell: 0.3; expect: (n) => fakeLab.tagged === n("bat") }
+    }
+
+    Flow {
+        id: verblessFlow
+        lab: fakeLab
+        flowId: "tst-verbless"
+        FlowStep { key: "nope"; dwell: 0.2; demo: [["noSuchVerb", 1], ["addPart", "led"]] }
+    }
+
+    Flow {
+        id: endlessFlow
+        lab: fakeLab
+        flowId: "tst-endless"
+        FlowStep { key: "never"; watch: ({ "until": () => false }) }
+    }
+
+    Flow {
+        id: wrongFlow
+        lab: fakeLab
+        flowId: "tst-wrong"
+        FlowStep { key: "claims"; dwell: 0.2; expect: () => false }
+        FlowStep { key: "throws"; dwell: 0.2; expect: () => nothingHere.atAll }
+    }
+
+    Flow {
+        id: unsolvableFlow
+        lab: fakeLab
+        flowId: "tst-unsolvable"
+        FlowStep {
+            key: "impossible"
+            task: ({ "until": () => false, "solve": [["addPart", "led"]] })
+        }
+    }
+
     TestCase {
         name: "Flow"
 
@@ -121,6 +180,8 @@ Item {
             fakeLab.nextId = 1
             fakeLab.tagged = -1
             flow.stop(); viewFlow.stop(); blindFlow.stop()
+            goodFlow.stop(); verblessFlow.stop(); endlessFlow.stop()
+            wrongFlow.stop(); unsolvableFlow.stop()
             fakeCam.lastCall = ""; fakeCam.lastArg = null
             fakeCam.calls = 0; fakeCam.partsWhenAimed = -1
         }
@@ -220,6 +281,73 @@ Item {
             blindFlow.next()
             compare(blindFlow.index, 1, "it walked the steps")
             compare(fakeCam.calls, 0, "and aimed nothing")
+        }
+
+        // --- Lab.runFlow: a flow walked with nobody watching (#207) ---------
+
+        function test_aHealthyFlowRunsToItsEnd() {
+            const r = Lab.runFlow("tst-good")
+            verify(r.error === undefined, "it had everything it needed")
+            verify(r.finished, "it reached the end rather than the bound")
+            compare(r.unresolvedVerbs, [], "every verb resolved")
+            compare(r.failedTasks, [], "the task was solved by the runner")
+            compare(r.failedExpects, [], "and the expect held")
+            compare(fakeLab.tagged, 1, "solve() really ran the lab's verb")
+            verify(r.steps > 0, "it advanced the clock")
+            verify(!goodFlow.running, "and left nothing running")
+        }
+
+        function test_headlessIsSetForTheRunAndRestoredAfter() {
+            compare(Lab.headless, false)
+            Lab.runFlow("tst-good")
+            compare(Lab.headless, false, "the flag does not outlive the run")
+        }
+
+        function test_pacingIsRestoredAfterTheRun() {
+            compare(goodFlow.pacing, "ready")
+            Lab.runFlow("tst-good")
+            compare(goodFlow.pacing, "ready", "auto was borrowed, not kept")
+        }
+
+        // A lab verb that does not resolve fails silently: the demo runs, the
+        // action does nothing, and the flow teaches nothing. The whole point
+        // of a headless run is that this is reported rather than warned about.
+        function test_anUnresolvedVerbIsReported() {
+            const r = Lab.runFlow("tst-verbless")
+            compare(r.unresolvedVerbs, ["noSuchVerb"])
+            verify(r.finished, "the rest of the step still ran")
+            compare(fakeLab.parts.length, 1, "including the verb that did resolve")
+        }
+
+        function test_theMaxStepsBoundIsHonoured() {
+            const r = Lab.runFlow("tst-endless", { maxSteps: 120 })
+            compare(r.steps, 120, "it stopped at the bound")
+            compare(r.finished, false, "and says so rather than claiming success")
+            verify(!endlessFlow.running, "the bounded flow is left stopped")
+        }
+
+        function test_aWrongExpectLandsInFailedExpectsWithItsKey() {
+            const r = Lab.runFlow("tst-wrong")
+            compare(r.failedExpects.length, 2)
+            compare(r.failedExpects[0].step, "claims")
+            compare(r.failedExpects[0].index, 0)
+            compare(r.failedExpects[1].step, "throws")
+            verify(r.failedExpects[1].error !== undefined,
+                   "a predicate that throws is a failure with its message")
+        }
+
+        function test_aTaskThatSolveCannotSatisfyIsReported() {
+            const r = Lab.runFlow("tst-unsolvable", { solveGrace: 0.5 })
+            compare(r.failedTasks.length, 1)
+            compare(r.failedTasks[0].step, "impossible")
+            verify(r.steps < 20000, "it walked on instead of eating the budget")
+        }
+
+        function test_anUnknownFlowIsAnErrorNotAnEmptyRun() {
+            const r = Lab.runFlow("no-such-flow")
+            verify(r.error !== undefined, "it says why")
+            compare(r.finished, false)
+            compare(r.steps, 0)
         }
     }
 }

--- a/skills/clay-lab/SKILL.md
+++ b/skills/clay-lab/SKILL.md
@@ -901,10 +901,22 @@ Verify in this order (clay-crew skill has the full protocol):
    per feature — property pokes hide real bugs (a pick-scan via
    `mapFrom3DScene` gets you screen coords for click targets).
 5. **Kit JS**: run the node unit suite.
-6. **Flows as tests**: run each flow headless with `pacing: "auto"`;
-   every `demo` verb must resolve, every `task.until` must hold after
-   its `solve`, every `expect` must pass. A drifted lab breaks its own
-   lessons — that is the point.
+6. **Flows as tests**: one command per flow, no session and no
+   hand-written step loop —
+
+   ```bash
+   ./build/bin/clayrender labs/<lab>/Sandbox.qml --out /tmp/x.png \
+       --paused --result - --eval 'Lab.runFlow("<flowId>")'
+   ```
+
+   `Lab.runFlow()` forces `pacing: "auto"`, advances the clock in 1/60 s
+   steps and solves every task itself. The answer on stdout must read
+   `"finished": true` with `unresolvedVerbs`, `failedTasks` and
+   `failedExpects` all empty: a verb the lab does not have, a task its
+   own `solve` cannot satisfy and an `expect` that no longer holds are
+   each named with the step key they belong to. A drifted lab breaks its
+   own lessons — that is the point. `--paused` is not optional here: sim
+   time that the frame ticker already moved makes the run unrepeatable.
 7. **Measure, don't guess**, anything with a numeric knob (shadows,
    fades): parameter sweep + pixel sampling.
 
@@ -936,12 +948,11 @@ The loop, in order:
    only finite values, so `NaN` is the honest answer for "no reading" —
    it leaves a blank cell rather than repeating the last one.
 2. **Drive the run stepped, never live.** Frames are wall-clock, so a lab
-   left to play itself is not reproducible. Stop the ticker and advance
-   the clock:
+   left to play itself is not reproducible. `--paused` keeps the frame
+   ticker from ever starting; advance the clock yourself:
 
    ```bash
-   clayrender labs/<lab>/Sandbox.qml --out /tmp/x.png --frames 1 --eval "
-       clock._frameTicker.running = false;
+   clayrender labs/<lab>/Sandbox.qml --out /tmp/x.png --frames 1 --paused --eval "
        clock.seed = 42;
        applyScenario('open-sky');
        recorder.lab = '<lab>'; recorder.destination = 'labs/<lab>/records/open-sky-42.labrec';

--- a/skills/clay-lab/references/flows.md
+++ b/skills/clay-lab/references/flows.md
@@ -109,11 +109,19 @@ A step with none of the three just narrates.
   and replays only step k's demo. Progress dots are clickable. In Box2D
   labs a backward jump resumes from the scenario boundary, not the exact
   frame (see pitfalls).
-- **Every flow is also a test.** Run it headless with `pacing: "auto"`:
-  verbs must resolve, each `task.until` must hold after its `solve`,
-  each `expect` must pass. Give the key steps `expect` predicates with
-  the *measured* value — a drifted lab then breaks its own lesson
-  loudly instead of teaching a wrong number.
+- **Every flow is also a test.** One command walks it:
+
+  ```bash
+  clayrender labs/<lab>/Sandbox.qml --out /tmp/x.png \
+      --paused --result - --eval 'Lab.runFlow("<flowId>")'
+  ```
+
+  `Lab.runFlow()` forces `pacing: "auto"`, steps the clock at 1/60 s and
+  runs each task's `solve` itself, then reports `unresolvedVerbs`,
+  `failedTasks` and `failedExpects` (each with its step key) plus
+  `finished`. Give the key steps `expect` predicates with the *measured*
+  value — a drifted lab then breaks its own lesson loudly instead of
+  teaching a wrong number.
 - **End with a handoff**: explain the number the learner just produced
   ("2.4 V over 470 Ω is 5.1 mA"), then "now try it yourself" — and
   ideally a final *task* that verifies transfer ("build two bulbs in
@@ -150,9 +158,12 @@ A flow nobody finds teaches nobody. Ship all three:
 Implemented: `Flow`, `FlowStep`, `Narrator`, `FlowChip`, verbs-as-data
 with `let` bindings, task/watch/expect, checkpoint scrubbing, ripening
 pacing, `takeOver`, `LabLang` narration keys (the `flow.*` chrome lives
-in the kernel dictionary — never copy it into a lab). **Not yet built** (planned, don't
-reference in code): `FlowSet`, a flow picker, `FlowCursor` (animated
-pointer), callout bubbles, flows as files under `labs/<lab>/flows/`,
-resume-after-reload of a running flow, record mode, `flow --check`
-validation, gym integration. Declare flows inline in `Sandbox.qml` and
-expose `flows()` / `startFlow(id)` manually until then.
+in the kernel dictionary — never copy it into a lab), and the headless
+run `Lab.runFlow(flowId)` (every `Flow` registers itself with `Lab`
+under its `flowId`; `Lab.headless` is what the Narrator, the professor
+kit's `FlowGuide` and narration audio stand down for). **Not yet built**
+(planned, don't reference in code): `FlowSet`, a flow picker,
+`FlowCursor` (animated pointer), callout bubbles, flows as files under
+`labs/<lab>/flows/`, resume-after-reload of a running flow, record mode,
+gym integration. Declare flows inline in `Sandbox.qml` and expose
+`flows()` / `startFlow(id)` manually until then.

--- a/tools/render/main.cpp
+++ b/tools/render/main.cpp
@@ -11,6 +11,7 @@
 #include <claysettle.h>
 #include <claystorage.h>
 
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 
@@ -209,6 +210,20 @@ int main(int argc, char* argv[])
     QCommandLineOption scriptOpt("script",
         "Run a JS file in the root's context - the same thing as --eval for "
         "setups too long for one line.", "file");
+    QCommandLineOption resultOpt("result",
+        "Write what each --eval/--script evaluated to: a JSON array in "
+        "command-line order, one {\"source\", \"value\"} per fragment, to "
+        "this file or to stdout for '-'. A fragment that is an expression "
+        "answers with its value ('clock.time' -> 0); anything JSON cannot "
+        "carry answers with its String(). Values are captured where the "
+        "fragment runs, which is BEFORE --wait-for and the capture. Without "
+        "the flag nothing is captured.", "file|-");
+    QCommandLineOption pausedOpt("paused",
+        "Start with Clayground.paused set, before the sandbox root exists, so "
+        "no frame ticker ever runs and the first --eval sees clock.time === 0. "
+        "This is what a stepped, reproducible run wants: advance the clock "
+        "yourself (Lab.runFlow(), clock._advance(1/60)) instead of racing a "
+        "wall clock.");
     QCommandLineOption waitForOpt("wait-for",
         "Hold the capture until this expression is truthy: --wait-for "
         "'spawned.length === 12'. Exits 3 if it never is, rather than "
@@ -249,7 +264,8 @@ int main(int argc, char* argv[])
     QCommandLineOption widthOpt("width", "Scale the capture to this width.", "px");
 
     parser.addOptions({sbxOpt, prefsOpt, outOpt, sizeOpt, setOpt, evalOpt,
-                       scriptOpt, waitForOpt, waitMsOpt, framesOpt, settleOpt,
+                       scriptOpt, resultOpt, pausedOpt, waitForOpt, waitMsOpt,
+                       framesOpt, settleOpt,
                        settleMsOpt, dumpOpt, projectOpt, pickOpt, anchorOpt,
                        cropOpt, cropPadOpt, scaleOpt, widthOpt});
     parser.process(app);
@@ -294,32 +310,68 @@ int main(int argc, char* argv[])
         return fail(QString("cannot parse --size '%1'").arg(parser.value(sizeOpt)));
 
     RenderHost host;
+    host.setPausedOnLoad(parser.isSet(pausedOpt));
     if (!host.load(sandbox, size)) {
         for (const auto& e : host.errors())
             QTextStream(stderr) << "clayrender: " << e << "\n";
         return 1;
     }
 
+    // One entry per --eval/--script, in the order they ran. Filled only when
+    // --result asked for it: capturing a value needs a different wrapping, and
+    // a run without the flag must behave exactly as it always did.
+    const bool wantResults = parser.isSet(resultOpt);
+    QJsonArray results;
+
     for (const auto& step : collectSteps(app.arguments())) {
         QString error;
+        QJsonValue value;
         switch (step.kind) {
         case Step::Assign:
             if (!host.applyAssignment(step.value, &error))
                 return fail(error);
             break;
         case Step::Eval:
-            if (!host.evalScript(step.value, &error))
+            if (!host.evalScript(step.value, &error,
+                                 wantResults ? &value : nullptr))
                 return fail(QString("--eval '%1': %2").arg(step.value, error));
+            if (wantResults)
+                results.append(QJsonObject{{"source", step.value},
+                                           {"value", value}});
             break;
         case Step::Script: {
             QFile file(step.value);
             if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
                 return fail(QString("cannot read --script %1").arg(step.value));
             const QString source = QString::fromUtf8(file.readAll());
-            if (!host.evalScript(source, &error))
+            if (!host.evalScript(source, &error,
+                                 wantResults ? &value : nullptr))
                 return fail(QString("--script %1: %2").arg(step.value, error));
+            if (wantResults)
+                // The path, not the file's contents: that is what the command
+                // line said, and a setup script is not a one-liner to read
+                // back in a report.
+                results.append(QJsonObject{{"source", step.value},
+                                           {"value", value}});
             break;
         }
+        }
+    }
+
+    // Written here rather than at the end, because this is where the values
+    // were taken: a --wait-for that never comes true exits 3, and the numbers
+    // the run already produced are still worth having.
+    if (wantResults) {
+        const QString path = parser.value(resultOpt);
+        const QByteArray json =
+            QJsonDocument(results).toJson(QJsonDocument::Indented);
+        if (path == QLatin1String("-")) {
+            QTextStream(stdout) << QString::fromUtf8(json);
+        } else {
+            QFile file(path);
+            if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
+                return fail(QString("cannot write --result %1").arg(path));
+            file.write(json);
         }
     }
 

--- a/tools/render/renderhost.cpp
+++ b/tools/render/renderhost.cpp
@@ -100,6 +100,24 @@ bool RenderHost::load(const QString& sandboxFile, const QSize& size)
     if (!createRenderTarget(size))
         return false;
 
+    // Before the component, not after: SimClock starts its FrameAnimation from
+    // its own Component.onCompleted, and a pause flipped after that has
+    // already let sim time move - which is why every recipe in the repo used
+    // to open with `clock._frameTicker.running = false`.
+    if (m_pauseOnLoad) {
+        auto* clayground = m_engine->singletonInstance<QObject*>(
+            QStringLiteral("Clayground.Common"), QStringLiteral("Clayground"));
+        if (!clayground) {
+            m_errors << QStringLiteral(
+                "--paused: cannot reach the Clayground.Common singleton "
+                "(is bin/qml on the import path?)");
+            return false;
+        }
+        // An ordinary property whose binding tracks the dojo's time control.
+        // No dojo here, so writing it is simply the answer.
+        clayground->setProperty("paused", true);
+    }
+
     m_component = std::make_unique<QQmlComponent>(m_engine.get(),
                                                   QUrl::fromLocalFile(fi.absoluteFilePath()));
     if (m_component->isLoading()) {
@@ -223,7 +241,8 @@ bool RenderHost::applyAssignment(const QString& assignment, QString* error)
     return true;
 }
 
-bool RenderHost::evalScript(const QString& source, QString* error)
+bool RenderHost::evalScript(const QString& source, QString* error,
+                            QJsonValue* value)
 {
     if (!m_rootItem) {
         if (error) *error = QStringLiteral("nothing loaded");
@@ -231,6 +250,14 @@ bool RenderHost::evalScript(const QString& source, QString* error)
     }
 
     QString qmlError;
+    if (value) {
+        if (!ClayScene::evalValue(m_rootItem, source, value, &qmlError)) {
+            if (error) *error = qmlError;
+            return false;
+        }
+        return true;
+    }
+
     // Wrapped in a function body so several statements, local vars and an
     // early return all behave the way they do in the sandbox itself.
     const QString wrapped = QStringLiteral("(function(){\n%1\n})()").arg(source);

--- a/tools/render/renderhost.h
+++ b/tools/render/renderhost.h
@@ -3,6 +3,7 @@
 
 #include <clayscenehost.h>
 
+#include <QJsonValue>
 #include <QObject>
 #include <QSize>
 #include <QString>
@@ -60,6 +61,12 @@ public:
     // errors() when the QML fails to load or the render stack cannot start.
     bool load(const QString& sandboxFile, const QSize& size);
 
+    // Sets Clayground.paused before the root is created, so no frame ticker
+    // ever starts. Has to be decided before load(): SimClock's ticker is
+    // running by its own Component.onCompleted, and a flag flipped afterwards
+    // has already let sim time move. Call it before load() or not at all.
+    void setPausedOnLoad(bool paused) { m_pauseOnLoad = paused; }
+
     // Applies "<expression>=<value>" assignments in the root's own context, so
     // ids, dotted paths and JS values all work. Returns false on the first
     // failure - a picture of a state you did not reach is worse than an error.
@@ -68,7 +75,12 @@ public:
     // Runs statements in the root's own context for their side effect - the
     // half of "reach a state" that --set cannot express, because an assignment
     // cannot call anything. Returns false with the QML message on error.
-    bool evalScript(const QString& source, QString* error);
+    //
+    // With 'value' the fragment is evaluated for what it EVALUATES to as well
+    // (--result), which is a different wrapping - so a caller that does not
+    // ask for a value gets exactly the behaviour it always got.
+    bool evalScript(const QString& source, QString* error,
+                    QJsonValue* value = nullptr);
 
     // Renders n additional frames, giving animations and lazily-built scene
     // graph nodes a chance to appear.
@@ -106,4 +118,5 @@ private:
     int m_generation = 0;
     QStringList m_errors;
     bool m_initialized = false;
+    bool m_pauseOnLoad = false;
 };

--- a/tools/render/tests/run_render_tests.py
+++ b/tools/render/tests/run_render_tests.py
@@ -197,6 +197,131 @@ Item {
           code == 0 and centre_of(out_script) == (0xFF, 0x33, 0x66),
           f"exit {code} {centre_of(out_script)}")
 
+    # --result: the value of each fragment, not just "it did not throw" (#207).
+    def results_of(argv):
+        code, out, err = run(args.clayrender, argv + ["--result", "-"])
+        # The JSON array is written before the "shot.png (WxH)" line, so it is
+        # everything up to and including the closing bracket.
+        end = out.rfind("]")
+        try:
+            return code, json.loads(out[:end + 1]), err
+        except ValueError:
+            return code, None, out + err
+
+    code, got, err = results_of([state, "--out", os.path.join(tmp, "res.png"),
+                                 "--size", "60x40", "--eval", "spawned"])
+    check("--result gives an expression its value, not null",
+          code == 0 and got == [{"source": "spawned", "value": 0}], str(got)[:160])
+
+    code, got, _ = results_of([state, "--out", os.path.join(tmp, "res.png"),
+                               "--size", "60x40",
+                               "--eval", 'applyScenario("hot")',
+                               "--eval", "({ fill: String(fill), n: [1, 2] })"])
+    check("--result keeps one entry per fragment, in command-line order",
+          code == 0 and len(got) == 2 and got[0]["value"] is None
+          and got[1]["value"]["n"] == [1, 2], str(got)[:200])
+
+    # Several statements are not an expression, so the value is what the
+    # fragment RETURNS - and a fragment that returns nothing answers null.
+    code, got, _ = results_of([state, "--out", os.path.join(tmp, "res.png"),
+                               "--size", "60x40",
+                               "--eval", "var x = 2; return x * 3"])
+    check("a multi-statement fragment answers with what it returns",
+          code == 0 and got[0]["value"] == 6, str(got)[:160])
+
+    code, got, _ = results_of([state, "--out", os.path.join(tmp, "res.png"),
+                               "--size", "60x40", "--eval", "root"])
+    check("a value JSON cannot carry comes back as a readable string",
+          code == 0 and isinstance(got[0]["value"], str)
+          and got[0]["value"] != "", str(got)[:160])
+
+    # --result takes a different route into the scene, so the failure has to
+    # be checked on that route too: a throw is exit 1 with the message, never
+    # a null value quietly written into the array.
+    code, out, err = run(args.clayrender,
+                         [state, "--out", os.path.join(tmp, "res.png"),
+                          "--size", "60x40", "--result", "-",
+                          "--eval", "noSuchFunction()"])
+    check("a broken --eval under --result still fails loudly",
+          code == 1 and "noSuchFunction" in err and "value" not in out,
+          f"exit {code} {err.strip()[:80]}")
+
+    res_file = os.path.join(tmp, "result.json")
+    code, _, err = run(args.clayrender,
+                       [state, "--out", os.path.join(tmp, "res.png"),
+                        "--size", "60x40", "--eval", "spawned",
+                        "--result", res_file])
+    check("--result <file> writes the same array to disk",
+          code == 0 and json.load(open(res_file))[0]["value"] == 0,
+          f"exit {code} {err.strip()[:80]}")
+
+    # A sandbox with a sim clock, so --paused can be checked on the thing it
+    # exists for: sim time that has already moved by the first --eval.
+    write(os.path.join(tmp, "Clocked.qml"), """
+import QtQuick
+import Clayground.Lab
+Item {
+    SimClock { id: clock; sampleInterval: 0.1 }
+    Rectangle { anchors.fill: parent; color: "#101820" }
+}
+""")
+    clocked = os.path.join(tmp, "Clocked.qml")
+    code, got, err = results_of([clocked, "--out", os.path.join(tmp, "clk.png"),
+                                 "--size", "60x40", "--eval", "clock.time"])
+    ticked = got[0]["value"] if got else None
+    check("without --paused the frame ticker has already moved sim time",
+          code == 0 and isinstance(ticked, (int, float)) and ticked > 0,
+          f"exit {code} {ticked} {err.strip()[:80]}")
+
+    code, got, err = results_of([clocked, "--out", os.path.join(tmp, "clk.png"),
+                                 "--size", "60x40", "--paused",
+                                 "--eval", "clock.time"])
+    check("--paused means the first --eval sees clock.time === 0",
+          code == 0 and got and got[0]["value"] == 0,
+          f"exit {code} {str(got)[:120]} {err.strip()[:80]}")
+
+    # Lab.runFlow through clayrender: the whole point of the three flags
+    # together is that a lesson can be walked and asked what broke (#207).
+    write(os.path.join(tmp, "Flowed.qml"), """
+import QtQuick
+import Clayground.Lab
+Item {
+    id: root
+    property int taps: 0
+    function flowActions() { return { "tap": () => { root.taps += 1; return root.taps } } }
+    function flows() { return [demoFlow.flowId] }
+    function startFlow(id) {
+        if (id === demoFlow.flowId) { demoFlow.start(); return true }
+        return false
+    }
+    function viewState() { return { taps: root.taps } }
+    function applyViewState(s) { root.taps = s.taps }
+    SimClock { id: clock; sampleInterval: 0.1 }
+    Flow {
+        id: demoFlow
+        lab: root
+        flowId: "demo"
+        FlowStep { key: "tap"; dwell: 0.3; demo: [["tap"]] }
+        FlowStep {
+            key: "again"
+            task: ({ "until": () => root.taps === 2, "solve": [["tap"]] })
+        }
+        FlowStep { key: "check"; dwell: 0.3; expect: () => root.taps === 2 }
+    }
+    Rectangle { anchors.fill: parent; color: "#101820" }
+}
+""")
+    code, got, err = results_of([os.path.join(tmp, "Flowed.qml"), "--out",
+                                 os.path.join(tmp, "flow.png"), "--size",
+                                 "60x40", "--paused",
+                                 "--eval", 'Lab.runFlow("demo")'])
+    ran = got[0]["value"] if got else None
+    check("Lab.runFlow walks a flow headless and reports a clean run",
+          code == 0 and ran and ran["finished"] is True
+          and ran["failedExpects"] == [] and ran["failedTasks"] == []
+          and ran["unresolvedVerbs"] == [],
+          f"exit {code} {str(ran)[:160]} {err.strip()[:80]}")
+
     # The order on the command line is the order of application - the parser
     # groups values per option, so this is the check that keeps it honest.
     out_a = os.path.join(tmp, "order_a.png")

--- a/tools/scene/clayscenequery.cpp
+++ b/tools/scene/clayscenequery.cpp
@@ -3,6 +3,8 @@
 #include "clayscenequery.h"
 
 #include <QHash>
+#include <QJSEngine>
+#include <QJSValue>
 #include <QJsonDocument>
 #include <QMetaObject>
 #include <QMetaProperty>
@@ -696,6 +698,88 @@ bool callVoid(QQuickItem* root, const QString& expression, QString* error)
     if (expr.hasError()) {
         if (error) *error = expr.error().description();
         return false;
+    }
+    return true;
+}
+
+bool evalValue(QQuickItem* root, const QString& source, QJsonValue* value,
+               QString* error)
+{
+    if (value) *value = QJsonValue::Null;
+
+    if (!root) {
+        if (error) *error = QStringLiteral("nothing loaded");
+        return false;
+    }
+
+    auto* context = QQmlEngine::contextForObject(root);
+    if (!context) {
+        if (error) *error = QStringLiteral("the root has no QML context");
+        return false;
+    }
+
+    // "clock.time" is an expression STATEMENT, so a function body wrapped
+    // around it returns undefined - which would answer null to exactly the
+    // question --result exists to ask. So a fragment that parses as an
+    // expression gets a `return` put in front of it.
+    //
+    // The parse is done by DEFINING the function and never calling it: a
+    // fragment of several statements fails to compile that way and falls back
+    // to a plain body. Deciding it by evaluating and retrying would run every
+    // side effect twice.
+    QString fragment = source.trimmed();
+    if (fragment.endsWith(QLatin1Char(';')))
+        fragment.chop(1);
+
+    QJSEngine* js = context->engine();
+    const bool asExpression =
+        js && !js->evaluate(QStringLiteral("(function(){\nreturn (\n%1\n)\n})")
+                            .arg(fragment)).isError();
+
+    const QString body = asExpression
+        ? QStringLiteral("return (\n%1\n)").arg(fragment)
+        : source;
+
+    // The value crosses as JSON text with a tag on it. JSON.stringify answers
+    // `undefined` for a function, a QML object and undefined itself, and none
+    // of those mean the JSON null a caller would otherwise read.
+    const QString wrapped = QStringLiteral(
+        "(function(){\n"
+        "  var __v = (function(){\n%1\n})();\n"
+        "  if (__v === undefined) return { kind: 'undefined' };\n"
+        "  try {\n"
+        "    var __s = JSON.stringify(__v);\n"
+        "    if (__s === undefined) return { kind: 'text', text: String(__v) };\n"
+        "    return { kind: 'json', text: __s };\n"
+        "  } catch (e) { return { kind: 'text', text: String(__v) }; }\n"
+        "})()").arg(body);
+
+    QQmlExpression expr(context, root, wrapped);
+    const QVariant out = expr.evaluate();
+    if (expr.hasError()) {
+        if (error) *error = expr.error().description();
+        return false;
+    }
+    if (!value)
+        return true;
+
+    const QVariantMap map = out.toMap();
+    const QString kind = map.value(QStringLiteral("kind")).toString();
+    if (kind == QLatin1String("text")) {
+        *value = map.value(QStringLiteral("text")).toString();
+    } else if (kind == QLatin1String("json")) {
+        // A bare scalar is not a JSON document, so it is parsed inside an
+        // array - the one way to read `0` and `{...}` through the same call.
+        const QByteArray text =
+            map.value(QStringLiteral("text")).toString().toUtf8();
+        QJsonParseError problem{};
+        const QJsonDocument doc =
+            QJsonDocument::fromJson("[" + text + "]", &problem);
+        if (problem.error == QJsonParseError::NoError && doc.isArray()
+            && doc.array().size() == 1)
+            *value = doc.array().at(0);
+        else
+            *value = QJsonValue(QString::fromUtf8(text));
     }
     return true;
 }

--- a/tools/scene/clayscenequery.h
+++ b/tools/scene/clayscenequery.h
@@ -104,6 +104,16 @@ QJsonValue callJsonFunction(QQuickItem* root, const QString& functionName);
 bool callVoid(QQuickItem* root, const QString& expression,
               QString* error = nullptr);
 
+// Evaluates a fragment for its VALUE and hands it back as JSON.
+//
+// A fragment that parses as an expression yields what it evaluates to
+// ("clock.time" -> 0); anything longer yields what it returns, or null. What
+// JSON cannot carry - a QML object, a function, NaN, undefined - comes back as
+// its String(), because an unreadable answer is worse than an approximate one.
+// Returns false with the QML message for a fragment that throws.
+bool evalValue(QQuickItem* root, const QString& source, QJsonValue* value,
+               QString* error = nullptr);
+
 // Evaluates an expression and reports whether it is truthy. 'error' is filled
 // only for a broken expression - a typo must not read the same as "the
 // condition is not met yet".


### PR DESCRIPTION
`clayrender` grows `--result` and `--paused`, and the lab kernel grows
`Lab.runFlow(flowId)`, so a lab can be asked a question and answer it on stdout
without a dojo session or a hand-written step loop.

- `--result <file|->` writes a JSON array, one `{source, value}` per
  `--eval`/`--script` in command-line order. A fragment that parses as an
  expression answers with its value (`clock.time` → `0`, not `null`); several
  statements answer with what they `return`; anything JSON cannot carry answers
  with its `String()`. Without the flag nothing changes.
- `--paused` sets `Clayground.paused` before the root is created, so
  `SimClock._frameTicker` never starts — the incantation
  `clock._frameTicker.running = false` that opened every recipe in the repo.
- `Lab.runFlow(flowId, opts)` forces `pacing: "auto"`, advances `Lab.clock` in
  1/60 s steps and runs each task's own `solve()`, returning
  `{flowId, steps, unresolvedVerbs, failedTasks, failedExpects, finished}`.
  `opts.maxSteps` (default 20000) bounds it; hitting the bound is
  `finished: false`, never a hang.
- Every `Flow` registers itself with `Lab` under its `flowId` (the same rule
  `Parameter` follows), and records the verbs a demo asked for and did not get.
- `Lab.headless` is set for the run and restored after: `Narrator` hides, the
  professor kit's `FlowGuide` skips arrival and travel, and `Professor.tell()` /
  `say()` load no narration clip — which is what keeps a lesson under two
  seconds instead of decoding every `.wav` through ffmpeg.

Verified:
- `ctest --preset default` → exit 0, 46/46 tests passed
- `qml_lab_qml` → 129 passed, 0 failed; 8 new `Flow::test_*` cases including
  `test_anUnresolvedVerbIsReported`, `test_theMaxStepsBoundIsHonoured` and
  `test_aWrongExpectLandsInFailedExpectsWithItsKey` (issue criteria 3 and 4)
- `clayrender` suite → 46/46 checks passed, 6 of them new (`--result` value,
  order, file, error path; `--paused`; `Lab.runFlow` end to end)
- criterion 1, all three flows exit 0 with `finished: true`, `failedExpects: []`:
  `led-basics` 1.2 s / 5292 steps, `logic-gates` 2.2 s / 10716 steps,
  `fusion-basics` 5.8 s / 5349 steps (`wheel-basics` 5598 steps too)
- criterion 2, `--paused --result - --eval 'clock.time'` printed `0` for
  electronics-101, sensor-fusion-101, hydraulics-101 and street-network-101
- `15 files changed, 786 insertions(+), 30 deletions(-)`

Not verified: Linux and Windows — everything above was run on macOS with
Qt 6.11.1 only. The QDoc pass over the new `Lab`/`Flow` doc comments was not
run (`-DCLAY_BUILD_DOCS=ON` was off).

<details><summary>Flow resolution, the expect timing, the deliberately-wrong-expect run, and one pre-existing test flake</summary>

**How a flow is resolved.** The issue says "resolves the flow through the
root's `flows()`/`startFlow()`". `Lab` has no reference to the sandbox root, so
resolution is by registry — each `Flow` files itself under its `flowId`, the way
`Parameter` and `Probe` already do — and *starting* goes through the root's own
`startFlow(flowId)` when it has one, falling back to `flow.start()`. A lab that
does more than start the flow in `startFlow()` still gets to do it. If neither
route leaves the flow running, the result carries `error` rather than a silent
`steps: 0, finished: true`.

**When `expect` is asserted.** On `Flow.index` changing, not from the driving
loop. `goTo()` assigns `index` *before* it runs the next step's demo, so the
handler is the last instant at which the lab still holds the state the finished
step produced; noticing the change from the loop would assert it against the
next step's setup.

**A task its own `solve` cannot satisfy** is reported and walked past after
`opts.solveGrace` sim seconds (default 5) rather than eating the whole step
budget and hiding every step after it.

**Criterion 3 against a real lab** — the `lit` step of `led-basics` with its
`expect` replaced by `() => false`:

```
$ clayrender labs/electronics-101/Sandbox.qml --out /tmp/e.png --paused --result - \
    --eval 'var f = null; for (var i = 0; i < ledFlow.steps.length; ++i) if (ledFlow.steps[i].key === "lit") f = ledFlow.steps[i]; f.expect = function() { return false }; return f.key' \
    --eval 'Lab.runFlow("led-basics")'
[
    { "source": "...return f.key", "value": "lit" },
    { "source": "Lab.runFlow(\"led-basics\")", "value": {
        "failedExpects": [ { "index": 6, "step": "lit" } ],
        "failedTasks": [], "finished": true, "flowId": "led-basics",
        "steps": 5292, "unresolvedVerbs": [] } }
]
```

**The live path is unchanged.** `startFlow("led-basics")` without `runFlow`
still satisfies `--wait-for 'prof.present && ledFlow.running && !Lab.headless'`
(exit 0), and after a headless run `prof.present` is `false`, `prof.line` is
`""` and `Lab.headless` is back to `false`.

**One pre-existing flake, not a regression.** The first `ctest` on this fresh
worktree failed `testsbx_plugin` — `module "Clayground.MyPlugin" plugin
"MyPluginplugin" not found`. The app bundle's
`Contents/Resources/qml/Clayground/MyPlugin/` was missing
`libMyPluginplugin.dylib`: `clayapp.cmake`'s `POST_BUILD copy_directory` of
`bin/qml` runs only when the app itself relinks, so a first parallel build can
copy the directory before the example plugin's dylib lands (the #188 family).
Forcing a relink of `sbx_plugin` makes it pass, and the same test passes in the
main checkout's build. Nothing in this diff touches `examples/pluginlive`.

**Follow-up noticed, not done:** the committed record drivers under
`labs/*/records/make.sh` still open with `clock._frameTicker.running = false`.
They keep working; `--paused` is what the skill now tells authors to use.

</details>

Closes #207
