### PR TITLE
webdojo: 3D assets on the Web Runtime - Timeline and AssetUtils linked, QFile assets preloaded into /game/

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -23,7 +23,7 @@ env:
   QT_VERSION_WASM: '6.10.1'
   QT_VERSION_HOST: '6.10.1'
   # Note: qtquick3dphysics excluded - crashes browser in WASM (not yet supported)
-  QT_MODULES: 'qtmultimedia qtquick3d qtshadertools qt5compat qtimageformats'
+  QT_MODULES: 'qtmultimedia qtquick3d qtquicktimeline qtshadertools qt5compat qtimageformats'
   EMSDK_VERSION: '4.0.7'
   # How many past releases to include in the site (each adds ~38 MB)
   MAX_RELEASE_VERSIONS: 5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ env:
   # Pin to 6.10.1 - wildcard causes issues when new versions are released (checksum propagation delays)
   QT_VERSION: '6.10.1'
   QT_VERSION_WASM: '6.10.1'
-  QT_MODULES: 'qtmultimedia qtquick3d qtquick3dphysics qtshadertools qt5compat qtimageformats'
+  QT_MODULES: 'qtmultimedia qtquick3d qtquick3dphysics qtquicktimeline qtshadertools qt5compat qtimageformats'
   CMAKE_BUILD_TYPE: Release
   AQT_VERSION: '>=3.2.0'
   EMSDK_VERSION: '4.0.7'

--- a/docs/docs/getting-started/your-website.md
+++ b/docs/docs/getting-started/your-website.md
@@ -51,16 +51,17 @@ Qt Quick 3D is in the runtime, and two more modules since v2026.7: `QtQuick.Time
 
 One wrinkle: Qt opens meshes, textures, `.qad` keyframe files and GLBs with `QFile`, which
 cannot read from a URL - a `Model { source: "meshes/x.mesh" }` served over HTTP silently
-shows nothing. So the app shell preloads them: list the files in an
-`assets-manifest.json` next to `Main.qml`
+shows nothing. So the app shell preloads them: keep such files under `assets/` next to
+`Main.qml` and run the script that ships in the folder
 
-```json
-["assets/orc/Orc.qml", "assets/orc/meshes/orc.mesh", "assets/orc/maps/diffuse.png",
- "assets/orc/animations/hips_rotation_0.qad"]
+```bash
+python3 make-assets-manifest.py        # -> assets-manifest.json, one entry per file under assets/
 ```
 
-and `index.html` fetches them into the in-memory filesystem under `/game/` before your
-game starts. Reference them with `file:///game/<path>`:
+whenever you add, rename or remove an asset. `index.html` fetches the listed files into the
+in-memory filesystem under `/game/` before your game starts; a file that cannot be fetched is
+logged in the console and skipped rather than blocking the start. Reference them with
+`file:///game/<path>`:
 
 ```qml
 Loader3D { source: "file:///game/assets/orc/Orc.qml" }        // balsam output, relative
@@ -69,9 +70,8 @@ RuntimeLoader { source: "file:///game/assets/orc.glb" }       // or the GLB itse
 ```
 
 `balsam model.glb -o assets/orc` (Qt's importer, part of any Qt install) produces the QML,
-`.mesh`, textures and `.qad` files; generate the manifest with a one-liner such as
-`find assets -type f | jq -R . | jq -s . > assets-manifest.json`. Everything else - QML,
-images, sounds - keeps loading by relative URL as before. A `.qml` referenced only by URL
+`.mesh`, textures and `.qad` files. Everything else - QML, images, sounds - keeps loading by
+relative URL as before. A `.qml` referenced only by URL
 is not compiled, so keep its imports to modules the runtime has; the console reports
 `module "X" is not installed` otherwise.
 

--- a/docs/docs/getting-started/your-website.md
+++ b/docs/docs/getting-started/your-website.md
@@ -43,6 +43,38 @@ wrinkle: QML *directory* imports over HTTP need a
 [`qmldir` file](https://doc.qt.io/qt-6/qtqml-modules-qmldir.html) listing the
 sibling components.
 
+## 3D models and animation
+
+Qt Quick 3D is in the runtime, and two more modules since v2026.7: `QtQuick.Timeline`
+(what balsam emits for skeletal animation clips) and `QtQuick3D.AssetUtils`
+(`RuntimeLoader`, glTF/GLB parsed at load time).
+
+One wrinkle: Qt opens meshes, textures, `.qad` keyframe files and GLBs with `QFile`, which
+cannot read from a URL - a `Model { source: "meshes/x.mesh" }` served over HTTP silently
+shows nothing. So the app shell preloads them: list the files in an
+`assets-manifest.json` next to `Main.qml`
+
+```json
+["assets/orc/Orc.qml", "assets/orc/meshes/orc.mesh", "assets/orc/maps/diffuse.png",
+ "assets/orc/animations/hips_rotation_0.qad"]
+```
+
+and `index.html` fetches them into the in-memory filesystem under `/game/` before your
+game starts. Reference them with `file:///game/<path>`:
+
+```qml
+Loader3D { source: "file:///game/assets/orc/Orc.qml" }        // balsam output, relative
+                                                             // meshes/maps/animations resolve
+RuntimeLoader { source: "file:///game/assets/orc.glb" }       // or the GLB itself
+```
+
+`balsam model.glb -o assets/orc` (Qt's importer, part of any Qt install) produces the QML,
+`.mesh`, textures and `.qad` files; generate the manifest with a one-liner such as
+`find assets -type f | jq -R . | jq -s . > assets-manifest.json`. Everything else - QML,
+images, sounds - keeps loading by relative URL as before. A `.qml` referenced only by URL
+is not compiled, so keep its imports to modules the runtime has; the console reports
+`module "X" is not installed` otherwise.
+
 ## Deploying
 
 Copy the folder to any static host — that is the whole deployment.

--- a/tools/webdojo/CMakeLists.txt
+++ b/tools/webdojo/CMakeLists.txt
@@ -90,6 +90,7 @@ add_custom_target(clayground_starter
         ${CMAKE_CURRENT_SOURCE_DIR}/appshell/index.html
         ${CMAKE_CURRENT_SOURCE_DIR}/appshell/Main.qml
         ${CMAKE_CURRENT_SOURCE_DIR}/appshell/README.md
+        ${CMAKE_CURRENT_SOURCE_DIR}/appshell/make-assets-manifest.py
         ${CMAKE_SOURCE_DIR}/docs/coi-serviceworker.js
         ${CMAKE_CURRENT_BINARY_DIR}/RUNTIME-MANIFEST.json
         ${CLAY_STARTER_DIR}/
@@ -98,7 +99,7 @@ add_custom_target(clayground_starter
         ${CLAY_STARTER_DIR}/LICENSES
     COMMAND ${CMAKE_COMMAND} -E chdir ${CLAY_STARTER_DIR}
         ${CMAKE_COMMAND} -E tar cf ${CMAKE_BINARY_DIR}/clayground-starter.zip --format=zip --
-        index.html Main.qml README.md clayground.js clayground.wasm
+        index.html Main.qml README.md make-assets-manifest.py clayground.js clayground.wasm
         qtloader.js coi-serviceworker.js RUNTIME-MANIFEST.json LICENSES
     DEPENDS webdojo
     COMMENT "Packaging Clayground starter bundle (clayground-starter.zip)"

--- a/tools/webdojo/CMakeLists.txt
+++ b/tools/webdojo/CMakeLists.txt
@@ -25,6 +25,8 @@ clay_app(webdojo
         Qt::QuickLayouts
         Qt::Quick3D
         Qt::Quick3DHelpers
+        Qt::Quick3DAssetUtils
+        Qt::QuickTimeline
         Qt::Sql
         Qt::Svg
         Qt6::QSvgPlugin

--- a/tools/webdojo/QmlModules.qml
+++ b/tools/webdojo/QmlModules.qml
@@ -7,6 +7,8 @@ import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Layouts
 import QtQuick3D.Helpers
+import QtQuick3D.AssetUtils   // RuntimeLoader: glTF/GLB straight from a URL
+import QtQuick.Timeline       // what balsam emits for skeletal animation clips
 import QtQuick.LocalStorage
 import QtQuick.Particles
 import QtMultimedia

--- a/tools/webdojo/appshell/Main.qml
+++ b/tools/webdojo/appshell/Main.qml
@@ -7,6 +7,8 @@
 // All Clayground modules are available, e.g.:
 //   import Clayground.Canvas   // 2D drawing
 //   import Clayground.World    // game world + physics
+//   import QtQuick3D           // 3D scenes; balsam-converted models and their
+//                              // QtQuick.Timeline clips, or RuntimeLoader (QtQuick3D.AssetUtils)
 // Explore live examples: https://mistergc.github.io/clayground/webdojo/
 
 import QtQuick

--- a/tools/webdojo/appshell/README.md
+++ b/tools/webdojo/appshell/README.md
@@ -35,10 +35,14 @@ you never have to think about it.
 ## 3D models, textures, animation clips
 
 Qt reads meshes, textures, balsam's `.qad` keyframes and GLB files with `QFile`, which
-cannot fetch from a URL. List those files in an `assets-manifest.json` next to `Main.qml`
-(a JSON array of relative paths) and `index.html` downloads them into the in-memory
-filesystem before your game starts. Refer to them as `file:///game/<path>` in QML, e.g.
-`Loader3D { source: "file:///game/assets/orc/Orc.qml" }`. Plain QML, images and sounds
+cannot fetch from a URL. Put such files under `assets/` and run
+
+    python3 make-assets-manifest.py            # writes assets-manifest.json
+
+whenever you add, rename or remove one; `index.html` downloads the listed files into the
+in-memory filesystem before your game starts. Refer to them as `file:///game/<path>` in QML,
+e.g. `Loader3D { source: "file:///game/assets/orc/Orc.qml" }`. A file that fails to download
+is logged in the console and skipped - the game still starts. Plain QML, images and sounds
 referenced from `Main.qml` keep working by relative URL as before.
 
 ## Check the runtime version

--- a/tools/webdojo/appshell/README.md
+++ b/tools/webdojo/appshell/README.md
@@ -32,6 +32,15 @@ Because the page is cross-origin isolated, assets from *other* domains need
 CORS/CORP headers - keep your game's assets in this folder (same origin) and
 you never have to think about it.
 
+## 3D models, textures, animation clips
+
+Qt reads meshes, textures, balsam's `.qad` keyframes and GLB files with `QFile`, which
+cannot fetch from a URL. List those files in an `assets-manifest.json` next to `Main.qml`
+(a JSON array of relative paths) and `index.html` downloads them into the in-memory
+filesystem before your game starts. Refer to them as `file:///game/<path>` in QML, e.g.
+`Loader3D { source: "file:///game/assets/orc/Orc.qml" }`. Plain QML, images and sounds
+referenced from `Main.qml` keep working by relative URL as before.
+
 ## Check the runtime version
 
 Open the browser console - the runtime prints a banner like

--- a/tools/webdojo/appshell/index.html
+++ b/tools/webdojo/appshell/index.html
@@ -76,14 +76,23 @@
                 list = await res.json();
             } catch (e) { return; }
             if (!Array.isArray(list) || list.length === 0) return;
-            let done = 0;
+            // Deliberate policy: a missing or unreadable asset is NOT fatal. The game still
+            // starts and Qt reports the file as missing where it is used (a model shows nothing,
+            // a sound stays silent) - better than a blank page because one of a hundred files
+            // was renamed. Every miss is logged so it is visible in the console.
+            let done = 0; const missing = [];
             const put = async (path) => {
-                const res = await fetch(path);
-                if (!res.ok) throw new Error(`asset ${path}: HTTP ${res.status}`);
-                const bytes = new Uint8Array(await res.arrayBuffer());
-                const full = '/game/' + path.replace(/^\.?\//, '');
-                runtime.FS.mkdirTree(full.substring(0, full.lastIndexOf('/')));
-                runtime.FS.writeFile(full, bytes);
+                try {
+                    const res = await fetch(path);
+                    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                    const bytes = new Uint8Array(await res.arrayBuffer());
+                    const full = '/game/' + path.replace(/^\.?\//, '');
+                    runtime.FS.mkdirTree(full.substring(0, full.lastIndexOf('/')));
+                    runtime.FS.writeFile(full, bytes);
+                } catch (e) {
+                    missing.push(path);
+                    console.warn(`Clayground: asset not preloaded - ${path} (${e.message})`);
+                }
                 loading.textContent = `Loading assets ${++done}/${list.length}…`;
             };
             // a few fetches at a time: enough parallelism, no connection storm
@@ -91,7 +100,8 @@
             await Promise.all(Array.from({ length: 6 }, async () => {
                 while (queue.length) await put(queue.shift());
             }));
-            console.log(`Clayground: preloaded ${done} asset file(s) into /game/`);
+            console.log(`Clayground: preloaded ${done - missing.length} asset file(s) into /game/`
+                        + (missing.length ? `, ${missing.length} missing` : ''));
         }
 
         async function boot() {

--- a/tools/webdojo/appshell/index.html
+++ b/tools/webdojo/appshell/index.html
@@ -68,6 +68,32 @@
             return false;
         }
 
+        async function preloadAssets(runtime, loading) {
+            let list;
+            try {
+                const res = await fetch('assets-manifest.json');
+                if (!res.ok) return;
+                list = await res.json();
+            } catch (e) { return; }
+            if (!Array.isArray(list) || list.length === 0) return;
+            let done = 0;
+            const put = async (path) => {
+                const res = await fetch(path);
+                if (!res.ok) throw new Error(`asset ${path}: HTTP ${res.status}`);
+                const bytes = new Uint8Array(await res.arrayBuffer());
+                const full = '/game/' + path.replace(/^\.?\//, '');
+                runtime.FS.mkdirTree(full.substring(0, full.lastIndexOf('/')));
+                runtime.FS.writeFile(full, bytes);
+                loading.textContent = `Loading assets ${++done}/${list.length}…`;
+            };
+            // a few fetches at a time: enough parallelism, no connection storm
+            const queue = list.slice();
+            await Promise.all(Array.from({ length: 6 }, async () => {
+                while (queue.length) await put(queue.shift());
+            }));
+            console.log(`Clayground: preloaded ${done} asset file(s) into /game/`);
+        }
+
         async function boot() {
             const loading = document.getElementById('loading');
             const screen = document.getElementById('screen');
@@ -87,6 +113,13 @@
                 // ... and hand over to your game. Everything referenced from
                 // Main.qml (images, sounds, more QML) is fetched relative to
                 // it - just put files next to it.
+                // Files Qt opens with QFile - Qt Quick 3D meshes and textures, balsam's
+                // Timeline keyframes (.qad), GLBs for RuntimeLoader - cannot come from an
+                // http URL. If the game ships an assets-manifest.json (a JSON array of
+                // relative paths), fetch them into the in-memory filesystem under /game/
+                // and reference them from QML as file:///game/<path>.
+                await preloadAssets(runtime, loading);
+
                 runtime.loadQmlFromUrl(new URL('Main.qml', window.location.href).href);
                 loading.style.display = 'none';
 

--- a/tools/webdojo/appshell/make-assets-manifest.py
+++ b/tools/webdojo/appshell/make-assets-manifest.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Write assets-manifest.json for the Clayground Web Runtime.
+
+    python3 make-assets-manifest.py [dir ...]        (default: assets)
+
+Lists every file under the given directories (relative to this script's folder, i.e. next to
+Main.qml) so index.html can preload them into the runtime's in-memory filesystem (/game/<path>)
+before your game starts. Run it whenever you add, rename or remove an asset file - a file that
+is on disk but not in the manifest is simply not preloaded, and Qt will report it as missing.
+"""
+import json
+import os
+import sys
+
+root = os.path.dirname(os.path.abspath(__file__))
+dirs = sys.argv[1:] or ["assets"]
+files = []
+for d in dirs:
+    base = os.path.join(root, d)
+    if not os.path.isdir(base):
+        print(f"warning: {d}/ not found next to {os.path.basename(__file__)}", file=sys.stderr)
+        continue
+    for dirpath, _, names in os.walk(base):
+        for n in sorted(names):
+            if n.startswith("."):
+                continue
+            files.append(os.path.relpath(os.path.join(dirpath, n), root).replace(os.sep, "/"))
+files.sort()
+out = os.path.join(root, "assets-manifest.json")
+with open(out, "w", encoding="utf-8") as f:
+    json.dump(files, f, indent=0)
+    f.write("\n")
+print(f"{out}: {len(files)} file(s) from {', '.join(dirs)}")

--- a/tools/webdojo/tests/wasm_smoke_test.py
+++ b/tools/webdojo/tests/wasm_smoke_test.py
@@ -33,7 +33,7 @@ MODULES_OK_MARKER = "SMOKE MODULES OK"
 FS_OK_MARKER = "SMOKE FS OK"
 # The app shell preloads asset files into the in-memory FS (/game/) so Qt can QFile-open
 # them; loading a QML file from there proves the mechanism end to end.
-FS_PROBE_JS = """
+FS_PROBE_JS = r"""
 window.clayground.FS.mkdirTree('/game/probe');
 window.clayground.FS.writeFile('/game/probe/Probe.qml',
     'import QtQuick\nItem { Component.onCompleted: console.log("%s") }');

--- a/tools/webdojo/tests/wasm_smoke_test.py
+++ b/tools/webdojo/tests/wasm_smoke_test.py
@@ -29,6 +29,29 @@ import threading
 BOOT_MARKER = "Clayground Web Runtime"
 QML_OK_MARKER = "QML loaded successfully"
 ERROR_MARKERS = ("QML Error", "Failed to create QML object")
+MODULES_OK_MARKER = "SMOKE MODULES OK"
+FS_OK_MARKER = "SMOKE FS OK"
+# The app shell preloads asset files into the in-memory FS (/game/) so Qt can QFile-open
+# them; loading a QML file from there proves the mechanism end to end.
+FS_PROBE_JS = """
+window.clayground.FS.mkdirTree('/game/probe');
+window.clayground.FS.writeFile('/game/probe/Probe.qml',
+    'import QtQuick\nItem { Component.onCompleted: console.log("%s") }');
+window.clayground.loadQmlFromUrl('file:///game/probe/Probe.qml');
+""" % FS_OK_MARKER
+# QML modules a deployed game may import - each one is linked into the runtime binary and
+# is missing at runtime (not at build time) if a link line or QmlModules.qml is forgotten.
+REQUIRED_MODULES = (
+    "QtQuick3D", "QtQuick3D.Helpers",
+    "QtQuick3D.AssetUtils",   # RuntimeLoader: glTF/GLB from a URL
+    "QtQuick.Timeline",       # balsam-exported skeletal animation clips
+    "QtMultimedia", "QtQuick.Particles", "QtQuick.LocalStorage",
+    "Clayground.Canvas3D", "Clayground.World", "Clayground.Behavior", "Clayground.Storage",
+)
+MODULE_PROBE_QML = "\n".join(f"import {m}" for m in REQUIRED_MODULES) + f"""
+import QtQuick
+Item {{ Component.onCompleted: console.log("{MODULES_OK_MARKER}") }}
+"""
 
 
 class IsolatedHandler(http.server.SimpleHTTPRequestHandler):
@@ -92,7 +115,7 @@ def run(args, serve_dir):
 
     from playwright.sync_api import sync_playwright
 
-    booted = qml_loaded = False
+    booted = qml_loaded = modules_ok = fs_ok = False
     # No --expect means nothing extra to wait for.
     marker_seen = not args.expect
     errors = []
@@ -106,7 +129,7 @@ def run(args, serve_dir):
         page = browser.new_page()
 
         def on_console(msg):
-            nonlocal booted, qml_loaded, marker_seen
+            nonlocal booted, qml_loaded, marker_seen, modules_ok, fs_ok
             text = msg.text
             print(f"[console] {text}")
             if BOOT_MARKER in text:
@@ -115,6 +138,10 @@ def run(args, serve_dir):
                 qml_loaded = True
             if args.expect and args.expect in text:
                 marker_seen = True
+            if MODULES_OK_MARKER in text:
+                modules_ok = True
+            if FS_OK_MARKER in text:
+                fs_ok = True
             if any(marker in text for marker in ERROR_MARKERS):
                 errors.append(text)
 
@@ -133,6 +160,21 @@ def run(args, serve_dir):
         if args.screenshot:
             page.screenshot(path=args.screenshot)
             print(f"Screenshot written to {args.screenshot}")
+        if qml_loaded and not errors:
+            # Second load: a QML snippet importing every module the runtime promises.
+            # A missing module surfaces as "QML Error: ... module is not installed".
+            page.evaluate("qml => window.clayground.loadQml(qml)", MODULE_PROBE_QML)
+            waited = 0
+            while waited < 30000 and not (modules_ok or errors):
+                page.wait_for_timeout(250)
+                waited += 250
+        if modules_ok and not errors:
+            # Third load: a QML file written into the preloaded-assets filesystem.
+            page.evaluate(FS_PROBE_JS)
+            waited = 0
+            while waited < 30000 and not (fs_ok or errors):
+                page.wait_for_timeout(250)
+                waited += 250
         browser.close()
     server.shutdown()
 
@@ -150,7 +192,13 @@ def run(args, serve_dir):
     if not marker_seen:
         print(f"FAIL: page never printed {args.expect!r}")
         return 1
-    print("PASS: runtime booted and Main.qml loaded without errors")
+    if not modules_ok:
+        print("FAIL: module probe did not load - a module from REQUIRED_MODULES is missing")
+        return 1
+    if not fs_ok:
+        print("FAIL: QML from the preloaded-assets filesystem (/game/) did not load")
+        return 1
+    print("PASS: runtime booted, Main.qml loaded, all required QML modules available, /game/ FS works")
     return 0
 
 


### PR DESCRIPTION
## Why

A game deployed as static files on the Web Runtime (`clayground-starter.zip`) could use Qt Quick 3D primitives but no authored models:

- balsam's output imports `QtQuick.Timeline` for skeletal clips, which the runtime did not link (`module "QtQuick.Timeline" is not installed`);
- Qt opens meshes, textures, `.qad` keyframes and GLBs with `QFile`, which cannot read from a URL, so `Model { source: "meshes/x.mesh" }` served over http silently renders nothing and `RuntimeLoader` reports `IO Error: File not found` without ever issuing a request.

Found while building [Ironfang](https://github.com/fernandotonon/Ironfang), a micro-RTS whose units come from QtMeshEditor (image → GLB → auto-rig → clips → balsam).

## What

- **Link `Qt::QuickTimeline` and `Qt::Quick3DAssetUtils`** into the runtime; `QmlModules.qml` imports them so the static plugins are pulled in; CI installs `qtquicktimeline`.
- **App shell preloads QFile assets.** If the site ships an `assets-manifest.json` (JSON array of relative paths), `index.html` fetches those files into the in-memory filesystem under `/game/` before `Main.qml` loads (6 parallel fetches, progress in the loading label). QML refers to them as `file:///game/<path>`; relative `meshes/`, `maps/`, `animations/` inside a balsam QML resolve from there. No manifest → nothing changes. The runtime already exports `FS`, so there are no C++ changes.
- **Smoke test** (`tools/webdojo/tests/wasm_smoke_test.py`) now also loads a snippet importing every module the runtime promises, and a QML file written into `/game/` — both failure modes are runtime-only and were invisible to the build.
- **Docs**: `your-website.md` gets a "3D models and animation" section; the starter README and `Main.qml` comment mention the workflow.

## Verification

- Built the starter with the Qt 6.11.1 `wasm_multithread` kit + Emscripten 4.0.7 (`cmake --build build-wasm --target clayground_starter`).
- Loaded Ironfang's QML + `assets/runtime` (95 files: balsam QML, `.mesh`, textures, 90 `.qad` clips) next to it, served with COOP/COEP, headless Chrome 152: `preloaded 95 asset file(s) into /game/`, the rigged Orc loads with clips `Attack, Death, Hit, Idle, Walk`, module probe OK, no console errors, 60 FPS. Before this change the same site logged `Unable to open keyframeSource: ""` for every track and the mesh/texture files were never requested.
- `python3 -m py_compile` on the smoke test; Playwright is not installed here, so the extended smoke test itself was exercised through an equivalent DevTools-protocol script rather than run as-is.

## Notes

- Runtime size: the two modules add a few hundred KB of wasm; the CI size report on this PR will show the exact delta (a local Qt 6.11.1 build is not comparable to the 6.10.1 release binary).
- `RuntimeLoader` becomes useful only together with the preload (GLB via `file:///game/...`), which is why both land in one PR.
- Follow-up candidate, kept out of this PR: `clayinit.cmake` sets `CMAKE_MODULE_PATH` and the output directories in Clayground's own directory scope only, so an external app that `add_subdirectory()`s Clayground must repeat both or `include(clayapp)` fails and `clay_app`'s post-link `bin/qml` copy has an empty source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
