### PR TITLE
clay_sound: audio no longer freezes the page on WebAssembly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,6 +156,16 @@ jobs:
         python3 tools/webdojo/tests/wasm_smoke_test.py build/clayground-starter \
           --screenshot starter-smoke.png
 
+    # Clayground.Sound's first audio-device query used to deadlock the page's
+    # main thread (#216) - a failure no desktop test can see.
+    - name: Sound Regression (WASM)
+      if: matrix.qt-target == 'wasm'
+      run: |
+        python3 tools/webdojo/tests/wasm_smoke_test.py build/clayground-starter \
+          --overlay tools/webdojo/tests/pages/sound \
+          --expect "clay-sound: audio device query returned" \
+          --timeout 90
+
     - name: Test
       if: matrix.qt-target == 'desktop'
       working-directory: build

--- a/plugins/clay_sound/CMakeLists.txt
+++ b/plugins/clay_sound/CMakeLists.txt
@@ -29,6 +29,7 @@ set(ENGINE_SRC
 
 set(CPP_SRC
     src/voice_waveform.h
+    src/audio_devices.cpp src/audio_devices.h
     src/audio_output.cpp src/audio_output.h
     src/softsynth.cpp src/softsynth.h
     src/synth_instrument.cpp src/synth_instrument.h

--- a/plugins/clay_sound/README.md
+++ b/plugins/clay_sound/README.md
@@ -159,6 +159,20 @@ Defaults: `dur=0.5` beats, `vel=0.8`.
   stage (AudioWorklet backend).
 - **Desktop/Mobile**: Full support — all types above work end-to-end.
 
+### What `Music` cannot do on WASM
+
+Qt's WebAssembly media backend plays a `Music` source through an HTML
+`<audio>` element and reports almost nothing back, so on the web
+(and only there):
+
+- `status` and `loaded` stay at their initial values until the track ends
+- `duration` and `position` stay `0`
+- `loop` has no effect — the track plays once
+
+A background loop on the web therefore needs a `Sound` re-triggered by a
+`Timer` at the clip length, the way `Music` was worked around before it
+played at all (see #216).
+
 ## Technical Notes
 
 - Audio is fully preloaded before playback (no streaming)

--- a/plugins/clay_sound/clay_sound.qdoc
+++ b/plugins/clay_sound/clay_sound.qdoc
@@ -85,6 +85,9 @@
     \li Audio files are fully preloaded before playback (no streaming)
     \li WASM: Browser autoplay policies require user interaction before audio plays
     \li WASM: Remote URLs must have CORS headers enabled
+    \li WASM: Music plays through an HTML audio element, which reports no
+        duration or position back and ignores \c loop; use a Sound
+        re-triggered by a Timer for a looping background track
     \li Desktop: Uses low-latency QSoundEffect for Sound, full-featured QMediaPlayer for Music
     \endlist
 

--- a/plugins/clay_sound/src/audio_devices.cpp
+++ b/plugins/clay_sound/src/audio_devices.cpp
@@ -1,0 +1,35 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+
+#include "audio_devices.h"
+
+// Q_OS_WASM comes from here - the guards below need it before anything else.
+#include <QtGlobal>
+
+#ifdef Q_OS_WASM
+#include <QCoreApplication>
+#include <QMediaDevices>
+#endif
+
+namespace clay::sound {
+
+void primeAudioDevices()
+{
+#ifdef Q_OS_WASM
+    static bool primed = false;
+    if (primed) return;
+    // QMediaDevices needs an application object; without one the probe
+    // would be pointless (and the deadlock unreachable anyway).
+    if (!QCoreApplication::instance()) return;
+    primed = true;
+
+    // Leaked on purpose: the probe must outlive every Sound/Music in the
+    // page, and Qt's device singleton lives for the whole process anyway.
+    auto *probe = new QMediaDevices;
+    // The connection itself is the point - the empty slot never matters.
+    // connectNotify() on the platform object is what constructs
+    // QWasmMediaDevices, and that populates inputs and outputs alike.
+    QObject::connect(probe, &QMediaDevices::audioOutputsChanged, probe, [] {});
+#endif
+}
+
+} // namespace clay::sound

--- a/plugins/clay_sound/src/audio_devices.h
+++ b/plugins/clay_sound/src/audio_devices.h
@@ -1,0 +1,31 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+//
+// primeAudioDevices() — one-time workaround for a self-deadlock in Qt's
+// WebAssembly audio-device backend. Call it before the first use of
+// QMediaDevices, QAudioSink, QAudioOutput or QMediaPlayer in a process.
+// No-op on every platform except WASM.
+
+#ifndef CLAY_SOUND_AUDIO_DEVICES_H
+#define CLAY_SOUND_AUDIO_DEVICES_H
+
+namespace clay::sound {
+
+// On Qt 6.11 for WebAssembly the first audio-device query hangs the
+// browser's main thread for good (#216): QPlatformAudioDevices::audioOutputs()
+// takes the write lock of its QCachedValue and calls findAudioOutputs(),
+// which constructs the QWasmMediaDevices singleton; that constructor calls
+// onAudioOutputsChanged(), which re-enters the same non-recursive
+// QReadWriteLock. Nothing ever releases it, so the tab freezes with no
+// error - both `Music` (QAudioOutput in its constructor) and the first
+// Sound.play() (QMediaDevices::defaultAudioOutput() in AudioOutput::start())
+// died there.
+//
+// Connecting to QMediaDevices::audioOutputsChanged builds QWasmMediaDevices
+// through QWasmAudioDevices::connectNotify() instead - outside the cache
+// lock. The later device query then finds the singleton already initialised
+// and never re-enters. Idempotent; safe to call from any of the entry points.
+void primeAudioDevices();
+
+} // namespace clay::sound
+
+#endif // CLAY_SOUND_AUDIO_DEVICES_H

--- a/plugins/clay_sound/src/audio_output.cpp
+++ b/plugins/clay_sound/src/audio_output.cpp
@@ -2,6 +2,7 @@
 
 #include "audio_output.h"
 
+#include "audio_devices.h"
 #include "engine/instrument.h"
 
 #include <QAudioDevice>
@@ -62,6 +63,9 @@ void AudioOutput::start()
     fmt.setSampleRate(SAMPLE_RATE);
     fmt.setChannelCount(1);
     fmt.setSampleFormat(QAudioFormat::Float);
+
+    // Must come before any QMediaDevices/QAudioSink use - see #216.
+    primeAudioDevices();
 
     const QAudioDevice outputDevice = QMediaDevices::defaultAudioOutput();
     if (outputDevice.isNull()) {

--- a/plugins/clay_sound/src/music.cpp
+++ b/plugins/clay_sound/src/music.cpp
@@ -2,12 +2,16 @@
 
 #include "music.h"
 
+#include "audio_devices.h"
+
 #include <QAudioOutput>
 #include <QDebug>
 #include <QMediaPlayer>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QQmlContext>
+#include <QQmlEngine>
 
 namespace {
 
@@ -21,11 +25,21 @@ bool isLocal(const QUrl &url)
         || s == QLatin1String("qrc");
 }
 
+#ifdef Q_OS_WASM
+constexpr bool WASM_PLAYS_URLS_DIRECTLY = true;
+#else
+constexpr bool WASM_PLAYS_URLS_DIRECTLY = false;
+#endif
+
 } // namespace
 
 Music::Music(QObject *parent)
     : QObject(parent)
 {
+    // QAudioOutput resolves the default device on construction, which is
+    // the call that used to hang the page on WASM - see #216.
+    clay::sound::primeAudioDevices();
+
     audioOut_ = new QAudioOutput(this);
     audioOut_->setVolume(volume_);
 
@@ -50,8 +64,17 @@ Music::~Music()
 
 void Music::setSource(const QUrl &url)
 {
-    if (source_ == url) return;
-    source_ = url;
+    // Same defensive resolution SampleInstrument does: QML auto-resolves
+    // relative URLs for a C++ QUrl property only in some type-binding paths,
+    // so `source: "music.mp3"` can arrive here unresolved and reach the
+    // backend as a bare filename.
+    QUrl resolved = url;
+    if (resolved.isRelative()) {
+        if (QQmlContext *ctx = QQmlEngine::contextForObject(this))
+            resolved = ctx->resolvedUrl(url);
+    }
+    if (source_ == resolved) return;
+    source_ = resolved;
     emit sourceChanged();
 
     cancelInFlightReply();
@@ -59,21 +82,26 @@ void Music::setSource(const QUrl &url)
     const bool hadError = hasError_;
     hasError_ = false;
 
-    if (url.isEmpty()) {
+    if (source_.isEmpty()) {
         resetSource();
         if (hadError) emit statusChanged();
         return;
     }
 
-    if (isLocal(url)) {
+    if (isLocal(source_) || WASM_PLAYS_URLS_DIRECTLY) {
         // Desktop / file:/qrc: — QMediaPlayer handles these directly.
+        // On WASM every scheme goes here: QWasmAudioOutput hands an http(s)
+        // URL straight to an HTML <audio> element, while its QIODevice
+        // overload only stores the device and never plays it — so the QBuffer
+        // detour below would leave the player at NoMedia, and prefetching
+        // would download the track a second time. (#216)
         // Drop any prior buffer so the player isn't pinned to old data.
         buffer_.reset();
-        player_->setSource(url);
+        player_->setSource(source_);
     } else {
-        // http(s) — pull bytes via QNAM, feed via QBuffer to dodge the
-        // QWasmMediaPlayer file-engine path that bails on URLs.
-        beginRemoteFetch(url);
+        // Desktop http(s) — pull bytes via QNAM and feed them through a
+        // QBuffer, so a backend that cannot open network URLs still plays.
+        beginRemoteFetch(source_);
     }
     if (hadError) emit statusChanged();
 }

--- a/plugins/clay_sound/src/music.h
+++ b/plugins/clay_sound/src/music.h
@@ -2,12 +2,19 @@
 //
 // Music — public QML-facing background music player.
 //
-// Wraps QMediaPlayer + QAudioOutput. On WASM, QMediaPlayer's backend
-// (QWasmMediaPlayer) tries to open the source URL through the local
-// file engine and bails on http(s). Music sidesteps that by pre-fetching
-// remote sources via QNetworkAccessManager and feeding the bytes through
-// a QBuffer with QMediaPlayer::setSourceDevice(). Local file:/qrc: paths
-// take the shortcut — they go straight to QMediaPlayer::setSource().
+// Wraps QMediaPlayer + QAudioOutput. Local file:/qrc: paths go straight
+// to QMediaPlayer::setSource(); on desktop, http(s) sources are pre-fetched
+// via QNetworkAccessManager and fed through a QBuffer with
+// QMediaPlayer::setSourceDevice(), so a backend that cannot open network
+// URLs still plays them.
+//
+// On WASM every source goes to setSource(): QWasmAudioOutput hands the URL
+// to an HTML <audio> element, and its QIODevice overload plays nothing.
+// What that backend does NOT do (#216): report mediaStatus beyond
+// EndOfMedia, report duration/position, or honour setLoops() — so `status`,
+// `loaded`, `duration`, `position` stay at their initial values there and
+// `loop` has no effect. Playback itself needs a user gesture first, as it
+// does for any audio in a browser.
 
 #ifndef CLAY_SOUND_MUSIC_H
 #define CLAY_SOUND_MUSIC_H

--- a/plugins/clay_sound/src/softsynth.cpp
+++ b/plugins/clay_sound/src/softsynth.cpp
@@ -5,6 +5,8 @@
 #include "engine/note_event.h"
 #include "engine/oscillator_voice.h"
 
+#include "audio_devices.h"
+
 #include <QAudioSink>
 #include <QMediaDevices>
 #include <QAudioDevice>
@@ -123,6 +125,9 @@ void SoftSynth::play()
     format.setSampleRate(SAMPLE_RATE);
     format.setChannelCount(CHANNELS);
     format.setSampleFormat(QAudioFormat::Float);
+
+    // Must come before any QMediaDevices/QAudioSink use - see #216.
+    clay::sound::primeAudioDevices();
 
     QAudioDevice outputDevice = QMediaDevices::defaultAudioOutput();
     if (outputDevice.isNull()) {

--- a/plugins/clay_sound/tests/CMakeLists.txt
+++ b/plugins/clay_sound/tests/CMakeLists.txt
@@ -23,6 +23,8 @@ add_executable(tst_clay_sound_engine
     ../src/engine/sample_voice.h
     ../src/engine/sampler_instrument.cpp
     ../src/engine/sampler_instrument.h
+    ../src/audio_devices.cpp
+    ../src/audio_devices.h
     ../src/audio_output.cpp
     ../src/audio_output.h
     ../src/synth_instrument.cpp
@@ -110,6 +112,8 @@ set_tests_properties(clay_sound_song_player PROPERTIES LABELS "clay_sound;unit")
 
 add_executable(tst_clay_sound_synth_bake
     tst_synth_bake.cpp
+    ../src/audio_devices.cpp
+    ../src/audio_devices.h
     ../src/audio_output.cpp
     ../src/audio_output.h
     ../src/synth_instrument.cpp

--- a/tools/webdojo/tests/pages/sound/Main.qml
+++ b/tools/webdojo/tests/pages/sound/Main.qml
@@ -1,0 +1,43 @@
+// Regression page for MisterGC/clayground#216 - overlaid onto the starter
+// bundle by wasm_smoke_test.py. Both halves of the freeze it guards against
+// only ever showed up in a browser:
+//
+//   * constructing Music creates a QAudioOutput, which resolves the default
+//     audio device;
+//   * the first triggered note opens the shared QAudioSink, which asks for
+//     the same device.
+//
+// On Qt 6.11 for WebAssembly that first device query deadlocked the page's
+// main thread, so the page below either loads and prints its marker within
+// seconds or the tab is frozen and the test times out.
+
+import QtQuick
+import Clayground.Sound
+
+Rectangle {
+    id: root
+    anchors.fill: parent
+    color: "#101018"
+
+    Music { id: music }
+    SynthInstrument { id: synth }
+
+    Text {
+        anchors.centerIn: parent
+        color: "#00d9ff"
+        font.pixelSize: 24
+        text: root.note
+    }
+    property string note: "creating audio objects"
+
+    Timer {
+        interval: 500
+        running: true
+        repeat: false
+        onTriggered: {
+            synth.triggerNote(60, 0.5, 0.2)
+            root.note = "audio device query returned"
+            console.log("clay-sound: audio device query returned")
+        }
+    }
+}

--- a/tools/webdojo/tests/wasm_smoke_test.py
+++ b/tools/webdojo/tests/wasm_smoke_test.py
@@ -5,8 +5,14 @@ Serves the starter directory with COOP/COEP headers, loads it in headless
 Chrome and asserts that the runtime boots (version banner) and Main.qml
 loads without QML errors.
 
+--overlay swaps in a different page (its files are copied over a temp copy
+of the starter bundle), and --expect adds a console marker the page must
+print. Together they turn this into a regression harness for anything that
+can only fail in the browser - see tests/pages/.
+
 Usage:
     python3 wasm_smoke_test.py <starter-dir> [--screenshot out.png] [--timeout 180]
+                               [--overlay dir] [--expect "marker"]
 
 Requires: pip install playwright
 Uses the system Chrome when available, otherwise a Playwright-managed
@@ -15,7 +21,9 @@ Chromium (python -m playwright install chromium).
 import argparse
 import functools
 import http.server
+import shutil
 import sys
+import tempfile
 import threading
 
 BOOT_MARKER = "Clayground Web Runtime"
@@ -52,18 +60,41 @@ def main():
     ap.add_argument("starter_dir")
     ap.add_argument("--screenshot", default="")
     ap.add_argument("--timeout", type=int, default=180)
+    ap.add_argument("--overlay", default="",
+                    help="directory copied over a temp copy of the starter bundle")
+    ap.add_argument("--expect", default="",
+                    help="console marker the page must print, on top of loading")
     args = ap.parse_args()
 
-    handler = functools.partial(IsolatedHandler, directory=args.starter_dir)
+    serve_dir = args.starter_dir
+    tmp_dir = ""
+    if args.overlay:
+        tmp_dir = tempfile.mkdtemp(prefix="wasm-smoke-")
+        shutil.copytree(args.starter_dir, tmp_dir, dirs_exist_ok=True)
+        shutil.copytree(args.overlay, tmp_dir, dirs_exist_ok=True)
+        serve_dir = tmp_dir
+        print(f"Overlaying {args.overlay}")
+
+    try:
+        return run(args, serve_dir)
+    finally:
+        if tmp_dir:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def run(args, serve_dir):
+    handler = functools.partial(IsolatedHandler, directory=serve_dir)
     server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
     port = server.server_address[1]
     threading.Thread(target=server.serve_forever, daemon=True).start()
     url = f"http://127.0.0.1:{port}/"
-    print(f"Serving {args.starter_dir} at {url}")
+    print(f"Serving {serve_dir} at {url}")
 
     from playwright.sync_api import sync_playwright
 
     booted = qml_loaded = False
+    # No --expect means nothing extra to wait for.
+    marker_seen = not args.expect
     errors = []
 
     with sync_playwright() as p:
@@ -75,13 +106,15 @@ def main():
         page = browser.new_page()
 
         def on_console(msg):
-            nonlocal booted, qml_loaded
+            nonlocal booted, qml_loaded, marker_seen
             text = msg.text
             print(f"[console] {text}")
             if BOOT_MARKER in text:
                 booted = True
             if QML_OK_MARKER in text:
                 qml_loaded = True
+            if args.expect and args.expect in text:
+                marker_seen = True
             if any(marker in text for marker in ERROR_MARKERS):
                 errors.append(text)
 
@@ -93,7 +126,7 @@ def main():
         # and always burn the full timeout even when the app boots in seconds.
         waited = 0
         deadline_ms = args.timeout * 1000
-        while waited < deadline_ms and not (qml_loaded or errors):
+        while waited < deadline_ms and not ((qml_loaded and marker_seen) or errors):
             page.wait_for_timeout(250)
             waited += 250
         page.wait_for_timeout(1500)  # let trailing errors and rendering arrive
@@ -113,6 +146,9 @@ def main():
         return 1
     if not qml_loaded:
         print("FAIL: Main.qml did not finish loading")
+        return 1
+    if not marker_seen:
+        print(f"FAIL: page never printed {args.expect!r}")
         return 1
     print("PASS: runtime booted and Main.qml loaded without errors")
     return 0


### PR DESCRIPTION
`Clayground.Sound` no longer freezes a WebAssembly page: `clay::sound::primeAudioDevices()` connects to `QMediaDevices::audioOutputsChanged` once before any device query, and every entry point that touches Qt Multimedia calls it first.

Qt 6.11's WASM backend self-deadlocks on that first query — `QPlatformAudioDevices::audioOutputs()` holds its `QCachedValue` write lock while `QWasmMediaDevices`' constructor re-enters the same non-recursive lock through `onAudioOutputsChanged()`. Connecting first builds the singleton via `QWasmAudioDevices::connectNotify()`, outside the lock.

- `Music`'s constructor, `clay::sound::AudioOutput::start()` (every `Sound`, `SampleInstrument`, `SynthInstrument`, `ChipTracker`, `SongPlayer`) and `SoftSynth::play()` prime the devices first; `primeAudioDevices()` is a no-op off WASM
- on WASM `Music` hands its URL straight to `QMediaPlayer::setSource()` — `QWasmAudioOutput`'s `QIODevice` overload only stores the device and never plays it, so the `QBuffer` detour left the player at `NoMedia` and downloaded the track twice
- `Music` now resolves a relative `source` against its QML context the way `Sound` already did — `source: "music.mp3"` reached the backend unresolved and failed with `Could not open file`
- `wasm_smoke_test.py` grew `--overlay` and `--expect`, and `tools/webdojo/tests/pages/sound/` is a page whose `Music` + first triggered note guard the deadlock; a new CI step runs it

Verified:
- `ctest --preset default` (macOS, Qt 6.11.1) → exit 0, 100% tests passed out of 51
- `wasm_smoke_test.py build-wasm/clayground-starter --overlay tools/webdojo/tests/pages/sound --expect "clay-sound: audio device query returned"` → exit 0; with `primeAudioDevices()` compiled out, the same command → exit 1, `FAIL: Main.qml did not finish loading`
- the issue's own repro (a `Music` on a 22 s 1 MB mono WAV, `loop: true`, no `Sound`) in the Web Runtime → exit 0, `QML loaded successfully`; before the fix the same page never loaded
- headless Chrome, after a real click: `Sound.play()` returns and `activeVoices` goes 0 → 1 → 0, and the `Music` audio element runs `paused:false, currentTime 3.94 → 6.94`
- `clayrender plugins/clay_sound/demo/Sandbox.qml --wait-for "bgMusic.status === 2"` → `SRC=file:///…/music.mp3 STATUS=2 DUR=30864`; before the relative-URL fix it was `[Music] invalid media: "Could not open file"`
- `13 files changed, 239 insertions(+), 18 deletions(-)`

Not verified: Linux and Windows (built and tested on macOS only); real audible output — the browser checks read the media element's clock and the engine's voice count, nobody listened; `SoftSynth::play()` and `ChipTracker` on WASM, reached by reading the call graph into `AudioOutput::start()`, not by running them.

<details><summary>How the deadlock was located, what still does not work in a browser, and two things left open</summary>

**Locating it.** Traces around each call in a `wasm_multithread` build, driven by headless Chrome: `[TRACE] Music: M1 before new QAudioOutput` and `[TRACE] start: B before QMediaDevices::defaultAudioOutput` were the last lines printed in the two freezing cases — `M2` and `C` never arrived. Reading Qt 6.11's `qplatformaudiodevices.cpp`, `qcachedvalue_p.h` and `qwasmmediadevices.cpp` gave the re-entrant `QReadWriteLock` above. `Music {}` with no `source` at all also froze, which put the blame on the constructor rather than the source path.

**What `Music` still cannot do on WASM** (Qt backend gaps, now documented in `plugins/clay_sound/README.md` and the qdoc):
- `status` and `loaded` stay at their initial values until the track ends — the backend reports no `LoadedMedia`
- `duration` and `position` stay `0`
- `loop` has no effect. `QWasmMediaPlayer` has no `setLoops()`, and restarting from the `EndOfMedia` callback (tried both synchronously and queued) buys exactly one extra lap — Qt's `ended` handler reaches the player only once. A one-lap "loop" is worse than a documented limit, so it is not in this PR.

Open, parked on the issue rather than decided here:
1. whether `Music` should run on the `clay::sound` engine on WASM instead of an HTML `<audio>` element — that would make `loop`, `status`, `duration` and `position` real, at the cost of WAV-only playback on the web.
2. `plugins/clay_character3d/src/speech.cpp:402` builds a `QMediaPlayer` + `QAudioOutput` in `Speech::startAudio()` and hits the identical deadlock the first time `sayAudio()` runs in a browser. Left untouched — it is a different plugin, and plugins here do not share code.

</details>

Closes #216
