### PR TITLE
A lesson owns the board; a task lends back only what it named

### DIFF
--- a/labs/electronics-101/Sandbox.qml
+++ b/labs/electronics-101/Sandbox.qml
@@ -1454,7 +1454,9 @@ Item {
         const f = currentFlow
         info.flow = { id: f.running ? f.flowId : "",
                       offered: f.flowId,
-                      step: f.index, paused: f.paused, waiting: f.waiting }
+                      step: f.index, waiting: f.waiting,
+                      // who has the board: "learner", "flow" or "task"
+                      control: f.control }
         info.ui = { selected: selectedId, snap: grid.snap,
                     watching: watch.map(id => ({ id: id, type: elemAt(id).type })),
                     quantity: monitor.quantity, lang: LabLang.lang }
@@ -1824,8 +1826,8 @@ Item {
     // The gesture is the kernel's (BoardInput): an empty hand wires pads,
     // selects and drags a part, taps a wire to branch from it, and operates
     // the SELECTED part's actuator on a second click. What this lab adds is
-    // what operating means here - a switch flips - and that a click on the
-    // board hands the flow over to the learner.
+    // what operating means here - a switch flips - and which flow owns the
+    // board while it teaches.
     BoardInput {
         id: boardMouse
         board: board
@@ -1834,8 +1836,11 @@ Item {
         stage: stage
         view: view3d
         grid: grid
+        // While a lesson runs the board is the lesson's: a task lends back
+        // exactly the part it asked for and takes it back the moment it is
+        // done, and everything else refuses out loud (#221).
+        flow: root.currentFlow
         onOperate: (id) => root.toggleSwitch(id)
-        onInteracted: root.currentFlow.takeOver()   // the learner is driving now, not the flow
     }
 
     // --- palette ----------------------------------------------------------
@@ -1919,6 +1924,7 @@ Item {
             task: ({ "until": (n) => { const e = root.elemAt(n("sw")); return e && e.on },
                      "hint": "flow.led-basics.flip.hint",
                      "hintAfter": 7,
+                     "allow": ["sw"],
                      "solve": [["flipSwitch", "sw"]] })
         }
         FlowStep {
@@ -1931,9 +1937,19 @@ Item {
             key: "values"
             demo: [["showValues", true]]
         }
+        // The handoff, and a task rather than a closing line: the lesson ends
+        // by lending the learner the one control it has been talking about,
+        // and ends FOR GOOD the moment they use it - after which the whole
+        // board is theirs.
         FlowStep {
             key: "try"
             demo: [["select", "res"], ["frame", "selection"]]
+            task: ({ "until": (n) => { const e = root.elemAt(n("res"))
+                                       return e && e.value !== 470 },
+                     "hint": "flow.led-basics.try.hint",
+                     "hintAfter": 9,
+                     "allow": ["res"],
+                     "solve": [["setOhms", "res", 220]] })
         }
     }
     // --- flow: from one transistor to XOR ----------------------------------
@@ -1955,9 +1971,12 @@ Item {
         }
         FlowStep {
             key: "switch"
+            // The subject is whatever the preset just put on the board, so
+            // the task names it with a function rather than a bound name.
             task: ({ "until": () => root.logicRowIndex() === 1,
                      "hint": "flow.logic-gates.switch.hint",
                      "hintAfter": 7,
+                     "allow": () => root.logicInputs,
                      "solve": [["setInputs", 1]] })
         }
         FlowStep {
@@ -1974,6 +1993,7 @@ Item {
             task: ({ "until": () => root.logicRowIndex() === 3,
                      "hint": "flow.logic-gates.andtask.hint",
                      "hintAfter": 8,
+                     "allow": () => root.logicInputs,
                      "solve": [["setInputs", 3]] })
             // the gate is what the preset claims it is, or this step fails
             expect: () => {
@@ -1999,6 +2019,7 @@ Item {
                                       return r === 1 || r === 2 },
                      "hint": "flow.logic-gates.xortask.hint",
                      "hintAfter": 8,
+                     "allow": () => root.logicInputs,
                      "solve": [["setInputs", 1]] })
             expect: () => {
                 const t = root.truthTable()
@@ -2025,6 +2046,7 @@ Item {
                                       return r === 1 || r === 2 },
                      "hint": "flow.logic-gates.chiptask.hint",
                      "hintAfter": 8,
+                     "allow": () => root.logicInputs,
                      "solve": [["setInputs", 1]] })
             // the package answers the same as the five transistors did
             expect: () => {
@@ -2708,6 +2730,10 @@ Item {
         id: selCard
         objectName: "partCard"
         board: board
+        // The card is up through most of a lesson - the flow selects each
+        // part as it explains it - so it reads throughout and only acts for
+        // the part the running task named (#221).
+        flow: root.currentFlow
         view: view3d
         camera: rig.camera
         monitor: monitor

--- a/labs/electronics-101/strings.js
+++ b/labs/electronics-101/strings.js
@@ -105,10 +105,8 @@ var dict = {
 
         // --- flow: led-basics (SPIKE) ---
         "flow.led-basics.title": "Why does the LED light?",
-        "flow.paused": "paused — you took over",
         "flow.next": "next ›",
         "flow.back": "‹ back",
-        "flow.resume": "resume",
         "flow.leave": "✕ leave",
         "flow.showme": "show me",
         "flow.watching": "watching…",
@@ -123,6 +121,7 @@ var dict = {
         "flow.led-basics.why": "Why 5.1 mA? The cell offers 4.5 V, the LED eats about 2.1 of them, and the rest — 2.4 V — falls across the resistor. 2.4 V over 470 Ω is 5.1 mA. The resistor sets the current.",
         "flow.led-basics.values": "Read it off the board: each part shows its own voltage and current. Same current everywhere in one ring — that is a series circuit.",
         "flow.led-basics.try": "Try it yourself: select the resistor and drag its slider. Less resistance, more current, brighter LED — until it gives up.",
+        "flow.led-basics.try.hint": "Its card is already up — drag the slider on it, or press h and l.",
 
         // --- flow: logic-gates ---
         "flow.logic-gates.title": "From one transistor to XOR",
@@ -243,10 +242,8 @@ var dict = {
 
         // --- flow: led-basics (SPIKE) ---
         "flow.led-basics.title": "Warum leuchtet die LED?",
-        "flow.paused": "angehalten — du hast übernommen",
         "flow.next": "weiter ›",
         "flow.back": "‹ zurück",
-        "flow.resume": "fortsetzen",
         "flow.leave": "✕ beenden",
         "flow.showme": "zeig es mir",
         "flow.watching": "beobachten…",
@@ -261,6 +258,7 @@ var dict = {
         "flow.led-basics.why": "Warum 5,1 mA? Die Zelle bietet 4,5 V, die LED nimmt davon etwa 2,1 — der Rest, 2,4 V, fällt über dem Widerstand ab. 2,4 V an 470 Ω sind 5,1 mA. Der Widerstand bestimmt den Strom.",
         "flow.led-basics.values": "Lies es am Brett ab: jedes Bauteil zeigt seine Spannung und seinen Strom. Überall derselbe Strom in einem Ring — das ist eine Reihenschaltung.",
         "flow.led-basics.try": "Probiere selbst: wähle den Widerstand und zieh seinen Schieber. Weniger Ohm, mehr Strom, hellere LED — bis sie aufgibt.",
+        "flow.led-basics.try.hint": "Seine Karte ist schon offen — zieh den Schieber darauf, oder drück h und l.",
 
         // --- flow: logic-gates ---
         "flow.logic-gates.title": "Von einem Transistor zum XOR",

--- a/labs/hydraulics-101/Sandbox.qml
+++ b/labs/hydraulics-101/Sandbox.qml
@@ -479,8 +479,10 @@ Item {
                      wiring: "hint.plumbing", selected: "hint.selected", selectedSnap: "hint.selected.snap",
                      selectedFree: "hint.selected.free", selectedFrame: "hint.selected.frame",
                      idle: "hint.idle.water" })
+        // While the lesson runs the board is the lesson's; its one task
+        // lends back the valve and takes it straight back (#221).
+        flow: wheelFlow
         onOperate: (id) => root.toggleValve(id)
-        onInteracted: wheelFlow.takeOver()
     }
 
     // --- HUD ------------------------------------------------------------------------------------
@@ -542,6 +544,7 @@ Item {
         id: selCard
         objectName: "partCard"
         board: board; view: view3d; camera: rig.camera; monitor: monitor; overlay: overlay
+        flow: wheelFlow     // reads throughout a lesson, acts only for what a task named
         titleOf: (e) => root.cardTitle(e)
         readingOf: (e) => { const s = root.simOf(e.id); return root.fmtP(Math.abs(s.dp)) + "   " + root.fmtQ(Math.abs(s.q)) }
         hintOf: (e) => LabLang.t(e.type === "pump" ? "card.hint.pump"
@@ -753,6 +756,7 @@ Item {
             task: ({ "until": (n) => { const e = board.partAt(n("valve")); return e && e.on },
                      "hint": "flow.wheel-basics.open.hint",
                      "hintAfter": 7,
+                     "allow": ["valve"],
                      "solve": [["openValve", "valve", true]] })
         }
         FlowStep {

--- a/plugins/clay_lab/BoardInput.qml
+++ b/plugins/clay_lab/BoardInput.qml
@@ -27,6 +27,10 @@ import Clayground.Lab
     \li a body - selects and starts a drag.
     \endlist
 
+    With a \l flow wired, that whole list is conditional: while a lesson runs
+    the board is the flow's, and only what the running task named answers at
+    all.
+
     The gesture lives in named functions (\l pressAt, \l moveAt, \l releaseAt,
     \l clickAt, \l dragFrom) rather than in the signal handlers, so a flow, a
     test or an agent can perform the SAME drag a hand does - the inspector can
@@ -38,12 +42,12 @@ import Clayground.Lab
     BoardInput {
         id: boardMouse
         board: board; nav: nav; hands: hands; stage: stage; view: view3d; grid: grid
+        flow: root.currentFlow                 // while it runs, the board is its
         onOperate: (id) => root.toggleSwitch(id)
-        onInteracted: root.currentFlow.takeOver()
     }
     \endqml
 
-    \sa Board, OrbitInput3D, InstrumentBelt, GridMode
+    \sa Board, OrbitInput3D, InstrumentBelt, GridMode, Flow
 */
 MouseArea {
     id: root
@@ -62,6 +66,28 @@ MouseArea {
     property var grid: null
 
     /*!
+        \qmlproperty var BoardInput::flow
+        \brief The lab's \l Flow. While one runs, it decides what the board answers to.
+
+        A lesson explains, hands over exactly the interaction it asked for,
+        takes the board back when that is done, and continues. With a flow
+        wired here that rule is the mouse's: a press is checked against
+        \l {Flow::grants()} before anything happens, a refused press says so
+        through \l {Flow::refuse()} instead of quietly doing nothing, and
+        hovering an inert part promises nothing - no highlight, no pointing
+        hand. Left null, every press is the learner's, which is what a lab
+        without a flow (and every flow written before this) gets.
+    */
+    property var flow: null
+
+    /*!
+        \qmlproperty bool BoardInput::gated
+        \readonly
+        \brief A flow is running, so it - not the learner - says what is live.
+    */
+    readonly property bool gated: flow !== null && flow !== undefined && flow.running
+
+    /*!
         \qmlproperty real BoardInput::dragSlop
         \brief World units a press must travel before it is a drag.
     */
@@ -74,9 +100,28 @@ MouseArea {
     signal operate(int id)
     /*!
         \qmlsignal BoardInput::interacted()
-        \brief The learner is driving now (a part was selected or operated) - what a flow's takeOver wants.
+        \brief A part was selected or operated - a touch that was allowed through.
+
+        Not emitted for a press a running \l flow refused: those did not
+        happen as far as the lab is concerned.
     */
     signal interacted()
+
+    /*!
+        \qmlmethod bool BoardInput::granted(var hit)
+        \brief Whether a running \l flow lets the learner touch what \a hit found.
+
+        Everything, with no flow running. With one: only a part the current
+        task named, and only \e as a part - a pad or a wire is the circuit
+        the lesson is teaching, and rewiring it mid-sentence is the thing
+        this exists to stop.
+    */
+    function granted(hit) {
+        if (!gated) return true
+        if (!hit) return false
+        if (hit.kind === "wire" || hit.kind === "terminal") return false
+        return flow.grants(hit.el)
+    }
 
     /*!
         \qmlproperty var BoardInput::hintKeys
@@ -168,7 +213,11 @@ MouseArea {
             if (dragged)
                 board.movePart(dragElem, board.colOf(w.x), board.rowOf(w.z), snapping(mods))
         } else {
-            board.hoverHit = board.hitAt(w.x, w.z)
+            // An inert part must not light up under the cursor: the highlight
+            // and the pointing hand both read off hoverHit, so a refused hit
+            // is no hit at all.
+            const h = board.hitAt(w.x, w.z)
+            board.hoverHit = granted(h) ? h : null
         }
     }
 
@@ -213,6 +262,11 @@ MouseArea {
         const w = worldAt(mx, my)
         pressW = w; dragged = false; dragElem = null
         const hit = w ? board.hitAt(w.x, w.z) : null
+        // Before anything the board would do with it: while a flow runs the
+        // board is the flow's, and a task lends back only what it named. A
+        // refused press says so rather than doing nothing - one that does
+        // nothing and says nothing reads as a broken lab.
+        if (gated && !granted(hit)) { flow.refuse(); return }
         // empty board (or off-board): a click there means "nothing"
         if (!hit) {
             board.selectedId = -1
@@ -286,12 +340,19 @@ MouseArea {
             operate(actuateElem)
             actuateElem = null
             dragElem = null; dragged = false
+            _done()
             return
         }
         // Nothing else operates on release: a part's state is set on its
         // card, or through the actuator once the part is selected.
         dragElem = null; dragged = false
+        _done()
     }
+
+    // The gesture is over: if it satisfied the running task, the board goes
+    // back to the flow NOW and not at the clock's next sample, which is late
+    // enough for a second click to undo what the first one just achieved.
+    function _done() { if (gated) flow.check() }
 
     /*!
         \qmlmethod void BoardInput::cancelAll()
@@ -299,6 +360,15 @@ MouseArea {
     */
     function cancelAll() {
         board.wiringFrom = null; board.eraser = false; board.selectedId = -1
+    }
+
+    // A step change can happen while the mouse is standing still - a task ends
+    // the instant its `until` holds - and a highlight left under the cursor
+    // would go on promising a click the board no longer answers.
+    Connections {
+        target: root.flow
+        enabled: root.flow !== null && root.flow !== undefined
+        function onIndexChanged() { if (root.board) root.board.hoverHit = null }
     }
 
     // A right CLICK is "put it down" - the RTS cancel. It empties the hand and

--- a/plugins/clay_lab/Flow.qml
+++ b/plugins/clay_lab/Flow.qml
@@ -14,6 +14,12 @@ import QtQuick
     Pacing is measured in \e sim seconds, so a flow traverses the same states
     live and headless, and \c SimClock.timeScale scales it.
 
+    While a flow runs the board is the flow's, and a task lends back exactly
+    the one interaction it asks for - see \l control. That is the whole
+    difference between a lesson and a demo somebody can walk over: the
+    professor cannot explain the current that flows while a second click is
+    reopening the switch.
+
     Example usage:
     \qml
     import Clayground.Lab
@@ -28,6 +34,7 @@ import QtQuick
         FlowStep {
             key: "flip"
             task: { "until": (n) => root.elemAt(n("sw")).on,
+                    "allow": ["sw"],          // the one thing that is live
                     "solve": [["flipSwitch", "sw"]] }
         }
     }
@@ -85,10 +92,34 @@ Item {
     */
     readonly property bool running: index >= 0
     /*!
-        \qmlproperty bool Flow::paused
-        \brief Set when the learner takes over.
+        \qmlproperty string Flow::control
+        \readonly
+        \brief Who has the board right now: \c "learner", \c "flow" or \c "task".
+
+        A lesson alternates the way a game tutorial does. While no flow runs
+        the board is the \c learner's and everything works. The moment one
+        starts it is the \c flow's: it is building and explaining, and a
+        touch on the board is refused rather than obeyed. A task step opens
+        exactly what it named (\l {FlowStep::task}{task.allow}) and nothing
+        else - that is \c task - and the instant its \c until holds the
+        board is the flow's again. Full control comes back by leaving the
+        flow (\l stop()), not by touching something mid-lesson.
+
+        \sa grants(), refusal
     */
-    property bool paused: false
+    readonly property string control: !running ? "learner" : (waiting ? "task" : "flow")
+
+    /*!
+        \qmlproperty string Flow::refusal
+        \brief LabLang key of why the last touch did nothing; "" again after a moment.
+
+        The refusal channel of a locked board, and the reason locking one is
+        not the same as ignoring the learner: a click that does nothing and
+        says nothing reads as a broken lab. \l Narrator renders it.
+
+        \sa refuse()
+    */
+    property string refusal: ""
     /*!
         \qmlproperty bool Flow::waiting
         \readonly
@@ -208,12 +239,15 @@ Item {
     function start() {
         _checkpoints = ({}); _names = ({})
         unresolvedVerbs = []
-        paused = false
+        refusal = ""
         goTo(0)
     }
 
-    /*! \qmlmethod void Flow::stop() */
-    function stop() { index = -1; paused = false; hintShown = false }
+    /*!
+        \qmlmethod void Flow::stop()
+        \brief Leaves the flow - and hands the whole board back, at once.
+    */
+    function stop() { index = -1; hintShown = false; refusal = "" }
 
     /*! \qmlmethod void Flow::next() */
     function next() {
@@ -243,7 +277,7 @@ Item {
         index = i
         stepTime = 0
         hintShown = false
-        paused = false
+        refusal = ""
         const s = steps[i]
         if (s.demo && s.demo.length) run(s.demo)
         applyView(s.view)          // after the demo: a step may frame what it built
@@ -276,10 +310,61 @@ Item {
     }
 
     /*!
-        \qmlmethod void Flow::takeOver()
-        \brief Pauses the flow because the learner touched the lab.
+        \qmlmethod bool Flow::grants(var id)
+        \brief May the learner touch part \a id right now?
+
+        True whenever no flow runs. While one does, only during a task step
+        and only for what that task's \c allow named - resolved through
+        \l nameOf, so a task names the part the way its \c until and its
+        \c solve do (\c {"allow": ["sw"]}). A task whose subject only exists
+        once its own demo has run gives a function instead
+        (\c {"allow": (n) => root.logicInputs}), evaluated per press. A task
+        that names nothing keeps the whole board live, which is what every
+        flow written before this existed still gets.
     */
-    function takeOver() { if (running && !waiting) paused = true }
+    function grants(id) {
+        if (!running) return true
+        const s = step
+        if (!s || !s.task) return false
+        let a = s.task.allow
+        if (a === undefined || a === null) return true
+        if (typeof a === "function") a = a(nameOf)
+        if (a === undefined || a === null) return true
+        for (const x of a) if (nameOf(x) === id) return true
+        return false
+    }
+
+    /*!
+        \qmlmethod void Flow::refuse()
+        \brief Says why the touch just refused did nothing, for a moment.
+    */
+    function refuse() {
+        refusal = control === "task" ? "flow.refuse.task" : "flow.refuse.busy"
+        _refuseTimer.restart()
+    }
+
+    /*!
+        \qmlmethod bool Flow::check()
+        \brief Re-tests the running task's \c until at once; advances if it holds.
+
+        The clock samples ten times a second, which is late enough for a
+        second click to land on a task the first one already satisfied - the
+        exact thing a locked board exists to stop. Whoever performed a granted
+        interaction calls this the moment the gesture is over, so the board is
+        the flow's again before the next press can arrive.
+    */
+    function check() {
+        if (!running || !waiting) return false
+        const s = step
+        if (!s.task.until || !s.task.until(nameOf)) return false
+        next()
+        return true
+    }
+
+    property Timer _refuseTimer: Timer {
+        interval: 2200
+        onTriggered: _flow.refusal = ""
+    }
 
     /*!
         \qmlmethod string Flow::sayOf(QtObject step)
@@ -354,7 +439,7 @@ Item {
     // Sim-time driven, never a wall clock: same states live and headless.
     property Connections _tick: Connections {
         target: Lab
-        enabled: _flow.running && !_flow.paused
+        enabled: _flow.running
         function onSampled(t) {
             const s = _flow.step
             if (!s) return
@@ -366,8 +451,10 @@ Item {
                 return
             }
             if (s.task) {
-                const done = s.task.until ? s.task.until(_flow.nameOf) : false
-                if (done) { _flow.next(); return }
+                // check() is also what a granted interaction calls the moment
+                // it is done, so this is the backstop rather than the only
+                // route out of a task
+                if (_flow.check()) return
                 const after = s.task.hintAfter !== undefined ? s.task.hintAfter : 6
                 if (!_flow.hintShown && _flow.stepTime > after) _flow.hintShown = true
                 return

--- a/plugins/clay_lab/FlowStep.qml
+++ b/plugins/clay_lab/FlowStep.qml
@@ -41,11 +41,20 @@ QtObject {
 
     /*!
         \qmlproperty var FlowStep::task
-        \brief What the learner must do: \c {{until, hint, hintAfter, solve}}.
+        \brief What the learner must do: \c {{until, allow, hint, hintAfter, solve}}.
 
         \c until is a predicate receiving a name lookup function and returning
         true once the step is satisfied; \c solve is an action list that
         performs it (used by "show me" and by the headless verification run).
+
+        \c allow is what the task hands over: the parts the learner may touch
+        while it runs, named the way \c until and \c solve name them
+        (\c {"allow": ["sw"]}), everything else on the board being inert until
+        the task is done. A step whose subject is whatever the preset it just
+        applied put there names it with a function of the same name lookup
+        instead (\c {"allow": (n) => root.logicInputs}). Leaving it out keeps
+        the whole board live, which is what a flow written before
+        \l {Flow::control} existed still gets.
     */
     property var task: null
 

--- a/plugins/clay_lab/LabKeys.qml
+++ b/plugins/clay_lab/LabKeys.qml
@@ -344,7 +344,12 @@ Item {
 
         While a flow runs, \c Space / \c → advance it and \c ← steps back, so
         the narration reads the same in every lab. The lab's own keys keep
-        working throughout - a flow never locks the lab.
+        working throughout: what a running flow takes is the board (see
+        \l {Flow::control}), not the key map - the view, the text size, the
+        help and the transport are the reader's at every moment. The one
+        exception is the selected part's card, whose \c h / \c l / \b Enter
+        go through \l selection and are refused for a part the flow has not
+        lent out.
     */
     function handle(ev) {
         // --- the name prompt, before ANYTHING: while it is open the keyboard

--- a/plugins/clay_lab/LabLang.qml
+++ b/plugins/clay_lab/LabLang.qml
@@ -194,10 +194,11 @@ QtObject {
     readonly property var _kernel: ({
         "en": {
             "lab.parameters": "PARAMETERS",
-            "flow.paused": "paused — you took over",
+            "flow.yourturn": "your turn",
             "flow.next": "next ›",
             "flow.back": "‹ back",
-            "flow.resume": "resume",
+            "flow.refuse.busy": "watch for a moment — the board is mine until I hand it over",
+            "flow.refuse.task": "not that one — do the thing I just asked for",
             "flow.leave": "✕ leave",
             "flow.showme": "show me",
             "flow.watching": "watching…",
@@ -285,10 +286,11 @@ QtObject {
         },
         "de": {
             "lab.parameters": "PARAMETER",
-            "flow.paused": "angehalten — du übernimmst",
+            "flow.yourturn": "du bist dran",
             "flow.next": "weiter ›",
             "flow.back": "‹ zurück",
-            "flow.resume": "fortsetzen",
+            "flow.refuse.busy": "schau kurz zu — das Brett gehört mir, bis ich es übergebe",
+            "flow.refuse.task": "nicht das — mach bitte das, worum ich eben gebeten habe",
             "flow.leave": "✕ beenden",
             "flow.showme": "zeig es mir",
             "flow.watching": "beobachten…",

--- a/plugins/clay_lab/Narrator.qml
+++ b/plugins/clay_lab/Narrator.qml
@@ -63,9 +63,9 @@ Rectangle {
                 font.pixelSize: LabTheme.fontBody; font.bold: true; font.letterSpacing: 1.2
                 font.family: LabTheme.monoFont
             }
-            Text {
-                visible: _nar.flow && _nar.flow.paused
-                text: LabLang.t("flow.paused")
+            Text {  // whose board it is right now, in one word
+                visible: _nar.flow && _nar.flow.control === "task"
+                text: LabLang.t("flow.yourturn")
                 color: LabTheme.accent; font.pixelSize: LabTheme.fontBody
                 font.family: LabTheme.monoFont
             }
@@ -82,11 +82,15 @@ Rectangle {
             lineHeight: 1.15
         }
 
-        Text {  // a task's hint, once the learner has had a moment
+        Text {  // a task's hint, once the learner has had a moment - and
+                // before that, an answer to a touch the flow refused: a click
+                // that does nothing and says nothing reads as a broken lab.
             width: parent.width
             visible: text !== ""
             text: {
-                if (!_nar.flow || !_nar.flow.hintShown) return ""
+                if (!_nar.flow) return ""
+                if (_nar.flow.refusal !== "") return LabLang.t(_nar.flow.refusal)
+                if (!_nar.flow.hintShown) return ""
                 const s = _nar.flow.step
                 return s && s.task && s.task.hint ? LabLang.t(s.task.hint) : ""
             }
@@ -143,12 +147,6 @@ Rectangle {
                     text: LabLang.t("flow.back")
                     TapHandler { onTapped: _nar.flow.prev() }
                 }
-                Action {
-                    visible: _nar.flow && _nar.flow.paused
-                    strong: true
-                    text: LabLang.t("flow.resume")
-                    TapHandler { onTapped: _nar.flow.paused = false }
-                }
                 // Next is always clickable on a narrated step - a learner who
                 // already knows this step must never be held back. What
                 // changes is how loudly it asks to be pressed: quiet with a
@@ -193,6 +191,9 @@ Rectangle {
                     }
                     TapHandler { onTapped: _nar.flow.next() }
                 }
+                // Leave is also how the board comes back: while a lesson
+                // runs it is the flow's, and this is the one control that
+                // hands the whole of it over again.
                 Action {
                     text: LabLang.t("flow.leave")
                     TapHandler { onTapped: _nar.flow.stop() }

--- a/plugins/clay_lab/PartCard.qml
+++ b/plugins/clay_lab/PartCard.qml
@@ -32,6 +32,7 @@ import Clayground.Lab
     PartCard {
         id: selCard
         board: board; view: view3d; camera: rig.camera; monitor: monitor; overlay: overlay
+        flow: root.currentFlow
         titleOf: (p) => root.cardTitle(p)
         readingOf: (p) => root.fmtV(root.simOf(p.id).v)
         adjust: (p, row, d) => root.adjustRow(p, row, d)
@@ -56,6 +57,32 @@ LabPanel {
     property var monitor: null
     /*! \qmlproperty var PartCard::overlay \brief The \l BoardOverlay the tag row pins into. */
     property var overlay: null
+    /*!
+        \qmlproperty var PartCard::flow
+        \brief The lab's \l Flow. While one runs, it says whether this card is live.
+
+        A flow selects parts as it explains them, so the card is up through
+        most of a lesson - and a slider that still moves under it is a learner
+        editing the circuit the next sentence quotes a number from. Wired
+        here, the card answers only for a part the running task named
+        (\l {Flow::grants()}); otherwise it reads, and a touch on it is
+        refused out loud rather than ignored.
+    */
+    property var flow: null
+
+    /*!
+        \qmlproperty bool PartCard::live
+        \readonly
+        \brief The card's controls act right now.
+    */
+    readonly property bool live: {
+        if (!flow || !flow.running) return true
+        // grants() is a function, so it registers no dependency of its own:
+        // these two are what make the card go inert again when the flow walks
+        // off the task that lent this part out.
+        flow.control; flow.index
+        return part !== null && flow.grants(part.id)
+    }
 
     /*! \qmlproperty var PartCard::titleOf \brief \c {(part) -> string}, the first line. */
     property var titleOf: (p) => LabLang.t("part." + p.type).toUpperCase()
@@ -154,22 +181,38 @@ LabPanel {
         function adjust(d) {
             const p = root.part
             if (!p) return false
+            if (!root.live) { root.flow.refuse(); return false }
             const row = root.focusedRow
-            if (row === "watch") { if (root.monitor) root.monitor.toggle(p.id); return true }
+            if (row === "watch") {
+                if (root.monitor) root.monitor.toggle(p.id)
+                root._done(); return true
+            }
             if (row === "label") {
                 const cyc = [""].concat(root.attributes)
                 const cur = (root.overlay && root.overlay.tags[p.id]) || ""
                 if (root.overlay)
                     root.overlay.setTag(p.id, cyc[((cyc.indexOf(cur) + d) % cyc.length + cyc.length) % cyc.length])
-                return true
+                root._done(); return true
             }
-            return root.adjust(p, row, d)
+            const ok = root.adjust(p, row, d)
+            if (ok) root._done()
+            return ok
         }
         function operate() {
             const p = root.part
-            return p ? root.operate(p) : false
+            if (!p) return false
+            if (!root.live) { root.flow.refuse(); return false }
+            const ok = root.operate(p)
+            if (ok) root._done()
+            return ok
         }
     }
+
+    // The card just did something the running task may have been waiting for.
+    // Asked here rather than left to the clock's next sample, for the same
+    // reason BoardInput asks: Enter on a switch is a discrete act, and a
+    // second one landing before the sample would undo the first.
+    function _done() { if (flow && flow.running) flow.check() }
 
     Connections {
         target: root.board
@@ -253,5 +296,23 @@ LabPanel {
             color: LabTheme.inkFaint; font.pixelSize: LabTheme.fontBody
             font.family: LabTheme.handFont
         }
+    }
+
+    // The card while the flow holds the board: it still READS - the lesson
+    // quotes the numbers on it - but nothing on it acts, and a touch is
+    // answered instead of swallowed.
+    //
+    // Reparented on purpose: LabPanel's default property stacks children in a
+    // Column, and a blocker that takes its turn in a column covers nothing.
+    MouseArea {
+        id: _blocker
+        enabled: !root.live
+        visible: enabled
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: if (root.flow) root.flow.refuse()
+        // Both in onCompleted, and the anchor only AFTER the reparent: an
+        // anchored item inside a Column is a warning on the console, and a
+        // lab that logs is a lab-check failure.
+        Component.onCompleted: { parent = root; anchors.fill = root }
     }
 }

--- a/plugins/clay_lab/tests/tst_flow.qml
+++ b/plugins/clay_lab/tests/tst_flow.qml
@@ -172,6 +172,42 @@ Item {
         }
     }
 
+    // --- who has the board (#221) -----------------------------------------
+    // A lesson explains, hands over exactly the interaction it asked for,
+    // takes the board back when that is done, and continues. These two flows
+    // are the whole of that contract: one that names its subject, one that
+    // names nothing and therefore keeps the pre-#221 behaviour.
+    Flow {
+        id: gatedFlow
+        lab: fakeLab
+        flowId: "tst-gated"
+        pacing: "manual"
+
+        FlowStep { key: "build"; demo: [["let", "sw", "addPart", "switch"],
+                                        ["let", "other", "addPart", "led"]] }
+        FlowStep {
+            key: "flip"
+            task: ({ "until": () => fakeLab.tagged !== -1,
+                     "allow": ["sw"],
+                     "solve": [["tagPart", "sw"]] })
+        }
+        FlowStep { key: "after" }
+    }
+
+    Flow {
+        id: openTaskFlow
+        lab: fakeLab
+        flowId: "tst-opentask"
+        pacing: "manual"
+
+        FlowStep { key: "build"; demo: [["let", "sw", "addPart", "switch"]] }
+        FlowStep {
+            key: "anything"
+            task: ({ "until": () => fakeLab.tagged !== -1,
+                     "solve": [["tagPart", "sw"]] })
+        }
+    }
+
     TestCase {
         name: "Flow"
 
@@ -182,6 +218,7 @@ Item {
             flow.stop(); viewFlow.stop(); blindFlow.stop()
             goodFlow.stop(); verblessFlow.stop(); endlessFlow.stop()
             wrongFlow.stop(); unsolvableFlow.stop()
+            gatedFlow.stop(); openTaskFlow.stop()
             fakeCam.lastCall = ""; fakeCam.lastArg = null
             fakeCam.calls = 0; fakeCam.partsWhenAimed = -1
         }
@@ -348,6 +385,93 @@ Item {
             verify(r.error !== undefined, "it says why")
             compare(r.finished, false)
             compare(r.steps, 0)
+        }
+
+        // --- who has the board (#221) ------------------------------------
+
+        function test_theBoardIsTheLearnersUntilAFlowStarts() {
+            compare(gatedFlow.control, "learner")
+            verify(gatedFlow.grants(1), "with nothing running, everything is live")
+            verify(gatedFlow.grants(999), "including a part that does not exist")
+        }
+
+        function test_aDemoStepLocksTheWholeBoard() {
+            gatedFlow.start()
+            compare(gatedFlow.control, "flow")
+            verify(!gatedFlow.grants(fakeLab.parts[0].id), "not even the switch")
+            verify(!gatedFlow.grants(fakeLab.parts[1].id))
+        }
+
+        function test_aTaskOpensWhatItNamedAndNothingElse() {
+            gatedFlow.start()
+            gatedFlow.next()
+            compare(gatedFlow.control, "task")
+            compare(gatedFlow.grants(gatedFlow.nameOf("sw")), true,
+                    "the part the task named answers")
+            compare(gatedFlow.grants(gatedFlow.nameOf("other")), false,
+                    "the one beside it does not")
+        }
+
+        // The bug this exists for: the task is satisfied, the flow is already
+        // narrating the result, and a second click is still landing on the
+        // board it was talking about.
+        function test_theBoardIsLockedAgainTheInstantTheTaskIsDone() {
+            gatedFlow.start()
+            gatedFlow.next()
+            fakeLab.tagPart(gatedFlow.nameOf("sw"))
+            verify(gatedFlow.check(), "check() saw the task was done")
+            compare(gatedFlow.index, 2, "and walked on")
+            compare(gatedFlow.control, "flow")
+            verify(!gatedFlow.grants(gatedFlow.nameOf("sw")),
+                   "the part the task lent out is the flow's again")
+        }
+
+        function test_checkIsANoOpOutsideAnUnsatisfiedTask() {
+            gatedFlow.start()
+            compare(gatedFlow.check(), false, "not on a demo step")
+            gatedFlow.next()
+            compare(gatedFlow.check(), false, "nor on a task nobody has done")
+            compare(gatedFlow.index, 1, "and it moved nothing")
+        }
+
+        function test_leavingHandsTheWholeBoardBack() {
+            gatedFlow.start()
+            verify(!gatedFlow.grants(fakeLab.parts[0].id))
+            gatedFlow.stop()
+            compare(gatedFlow.control, "learner")
+            verify(gatedFlow.grants(fakeLab.parts[0].id), "at once, with no step in between")
+        }
+
+        // The compatibility story: a task that names nothing is a task that
+        // asks for nothing in particular, and the whole board stays live.
+        function test_aTaskThatNamesNothingKeepsTheBoardLive() {
+            openTaskFlow.start()
+            verify(!openTaskFlow.grants(fakeLab.parts[0].id), "its demo step still locks")
+            openTaskFlow.next()
+            compare(openTaskFlow.control, "task")
+            verify(openTaskFlow.grants(fakeLab.parts[0].id))
+            verify(openTaskFlow.grants(4242), "anything at all")
+        }
+
+        function test_aRefusalIsSaidAndThenForgotten() {
+            gatedFlow.start()
+            compare(gatedFlow.refusal, "")
+            gatedFlow.refuse()
+            compare(gatedFlow.refusal, "flow.refuse.busy", "the flow is working")
+            gatedFlow.next()
+            gatedFlow.refuse()
+            compare(gatedFlow.refusal, "flow.refuse.task", "the learner clicked the wrong thing")
+            gatedFlow.stop()
+            compare(gatedFlow.refusal, "", "leaving clears it")
+        }
+
+        // The headless run performs each task through solve(), which drives
+        // the lab's verbs and never touches the input layer - so a locked
+        // board cannot lock the verification run out.
+        function test_theHeadlessRunSolvesAGatedFlowAnyway() {
+            const r = Lab.runFlow("tst-gated")
+            compare(r.failedTasks, [], "the task was solved")
+            verify(r.finished, "and the flow reached its end")
         }
     }
 }

--- a/skills/clay-lab/references/flows.md
+++ b/skills/clay-lab/references/flows.md
@@ -59,6 +59,7 @@ Flow {
         task: ({ "until": (n) => { const e = root.elemAt(n("sw")); return e && e.on },
                  "hint": "flow.led-basics.flip.hint",
                  "hintAfter": 7,    // sim seconds until the hint shows
+                 "allow": ["sw"],   // the one part that is live meanwhile
                  "solve": [["flipSwitch", "sw"]] })   // the "show me" path
     }
     FlowStep {
@@ -74,6 +75,8 @@ Flow {
 }
 Narrator { flow: ledFlow }          // bottom-centre; hide the hint bar
                                     // while ledFlow.running
+BoardInput { flow: ledFlow }        // and the board is the flow's while it runs
+PartCard   { flow: ledFlow }
 ```
 
 Three step kinds, by who acts:
@@ -81,22 +84,37 @@ Three step kinds, by who acts:
 - **demo** — the lab acts through its verbs; the learner watches.
 - **task** — the learner acts; `until` is a predicate on *lab state*
   ("the LED is lit"), never on a specific click, so there is always more
-  than one way to satisfy it. Escalation, all optional: narration →
-  after `hintAfter` sim-seconds the hint shows → *show me* runs `solve`.
-  Nobody is ever stuck.
+  than one way to satisfy it. `allow` names what the task lends out —
+  the parts that answer while it runs, written the way `until` and
+  `solve` write them (`"allow": ["sw"]`, or a function of the same
+  lookup when the subject is whatever the step's own preset put there).
+  Escalation, all optional: narration → after `hintAfter` sim-seconds
+  the hint shows → *show me* runs `solve`. Nobody is ever stuck.
 - **watch** — the *simulation* acts; the step ends when the world
   reaches the moment worth explaining. The narrator says "watching…"
-  instead of "your turn"; interruption there counts as taking over,
-  while acting during a task counts as participating (`takeOver()` is a
-  no-op while `waiting`).
+  instead of "your turn".
 
 A step with none of the three just narrates.
 
 ## Rules that make a flow teach
 
-- **A flow never locks the lab.** Input mid-flow pauses it (wire your
-  interaction handlers to call `flow.takeOver()`); the narrator offers
-  resume / replay / leave. No modal overlay, no disabled inputs.
+- **A lesson owns the board while it teaches** (#221). `Flow.control` is
+  `"learner"` (nothing running — everything works), `"flow"` (a demo or a
+  narrated step — the board is inert) or `"task"` (only what `allow`
+  named). The instant a task's `until` holds the board is the flow's
+  again, so a second click cannot undo what the first one just achieved.
+  Wire it by handing the flow to the input rather than by disabling
+  anything: `BoardInput { flow: root.currentFlow }` and
+  `PartCard { flow: root.currentFlow }`. A refused touch is *answered* —
+  `Flow.refuse()` puts a line in the narrator — because a click that does
+  nothing and says nothing reads as a broken lab. Full control comes back
+  by leaving (`flow.stop()`, the narrator's ✕), never by touching
+  something mid-lesson. A task with no `allow` keeps the whole board
+  live, which is what a flow written before this gets.
+  The camera is never gated: looking around is not touching.
+- **The headless run is not affected.** `Lab.runFlow()` performs each
+  task through `solve()`, i.e. through the lab's verbs, and never through
+  the input layer — so a locked board cannot lock `lab_check_<lab>` out.
 - **Pacing ripens, never forces.** `pacing: "ready"` (default): a
   reading-time estimate ripens the Next control — dimmed but **always
   clickable**, never disabled. `"auto"` advances on elapse (kiosk,
@@ -159,7 +177,7 @@ A flow nobody finds teaches nobody. Ship all three:
 
 Implemented: `Flow`, `FlowStep`, `Narrator`, `FlowChip`, verbs-as-data
 with `let` bindings, task/watch/expect, checkpoint scrubbing, ripening
-pacing, `takeOver`, `LabLang` narration keys (the `flow.*` chrome lives
+pacing, `control`/`grants`/`refuse` (#221), `LabLang` narration keys (the `flow.*` chrome lives
 in the kernel dictionary — never copy it into a lab), and the headless
 run `Lab.runFlow(flowId)` (every `Flow` registers itself with `Lab`
 under its `flowId`; `Lab.headless` is what the Narrator, the professor

--- a/tools/lab-new/templates/build/Sandbox.qml
+++ b/tools/lab-new/templates/build/Sandbox.qml
@@ -423,8 +423,10 @@ Item {
     BoardInput {
         id: boardMouse
         board: board; nav: nav; hands: hands; stage: stage; view: view3d; grid: grid
+        // While a flow runs the board is the flow's: a task lends back
+        // exactly what it named and takes it back the moment it is done.
+        flow: introFlow
         onOperate: (id) => root.flip(id)
-        onInteracted: introFlow.takeOver()
     }
 
     // --- HUD ---------------------------------------------------------------------
@@ -465,6 +467,7 @@ Item {
         id: selCard
         objectName: "partCard"
         board: board; view: view3d; camera: rig.camera; monitor: monitor; overlay: overlay
+        flow: introFlow     // reads throughout a lesson, acts only for what a task named
         titleOf: (p) => LabLang.t("part." + p.type).toUpperCase()
                         + (p.type === "block" ? "  " + LabLang.t("card.weight") + " " + LabLang.num(p.value, 0) : "")
         readingOf: (p) => LabLang.t(root.simOf(p.id).lit ? "card.lit" : "card.dark")
@@ -594,12 +597,15 @@ Item {
                    ["frame", "setup"]]
         }
         // task: the learner acts; `until` is a predicate on board state, so
-        // the card, the actuator and the h key all satisfy it
+        // the card, the actuator and the h key all satisfy it - and `allow`
+        // is the one part that is live while it runs, everything else on the
+        // board being the flow's
         FlowStep {
             key: "try"
             task: ({ "until": (n) => { const e = board.partAt(n("s")); return e && e.on },
                      "hint": "flow.{{id}}-intro.try.hint",
                      "hintAfter": 8,
+                     "allow": ["s"],
                      "solve": [["flip", "s"]] })
         }
         // expect: the assertion that makes the flow a test


### PR DESCRIPTION
`Flow` now says who has the board — `"learner"`, `"flow"` or `"task"` — and `BoardInput` and `PartCard` ask it before they act on a press. While a lesson runs the board is the lesson's; a task step lends back only the parts its new `allow` list names, and the moment its `until` holds the flow takes them back. `takeOver()`/`paused` are gone: there is no pause-and-drive state any more, so the "resume" control left the narrator with them.

- `FlowStep.task` takes `allow` — flow-local names (`"allow": ["sw"]`) or a function of the same name lookup when the subject is whatever the step's preset just placed (`"allow": (n) => root.logicInputs`). A task with no `allow` keeps the whole board live, so flows written before this are unchanged.
- A refused touch is answered, not swallowed: `Flow.refuse()` puts `flow.refuse.busy` / `flow.refuse.task` in the narrator's hint slot, and an inert part gets no hover highlight and no pointing-hand cursor.
- `Flow.check()` re-tests the running task the instant a granted gesture ends, instead of waiting for the clock's next sample 0.1 s later — that window is what let a second click reopen the switch.
- `PartCard` reads throughout a lesson but only acts for the part the task named; the electronics lab's `try` step is now a task lending out the resistor, so the lesson's last line is a real handoff and ends when the learner uses it.
- Wired in `electronics-101`, `hydraulics-101` and the `lab-new` build template; `skills/clay-lab/references/flows.md` replaces "a flow never locks the lab" with the new rule.

Verified:
- `ctest --preset default` → exit 0, 51/51 passed (`lab_check_electronics-101` passed in 72.51 s — the third `Done when`)
- `qmltestrunner -input plugins/clay_lab/tests/tst_flow.qml` → 28 passed, 0 failed (8 of them new, covering `control`, `grants`, `check`, refusals and leaving)
- `tools/lab-check/lab_check.py labs/electronics-101` → exit 0, 22/22 checks passed
- first `Done when`, driven through real clicks in the running lab (`clayrender --paused` + `--wait-for`): `step=flip control=task | grants sw=true led=false | clickLED selected=-1 refusal=flow.refuse.task swOn=false | clickSW1 selected=12 (sw=12)`
- second `Done when`, same run: `clickSW2 swOn=true step=lit control=flow | clickAgain swOn=true refusal=flow.refuse.busy control=flow | afterLeave control=learner grantsLED=true`
- the resistor's slider, same method: locked step → `live=false ... ohms=470->470 refusal=flow.refuse.busy`; `try` task → `live=true ... ohms=470->390`, then `running=false control=learner`
- `13 files changed, 470 insertions(+), 59 deletions(-)`

Not verified: nothing outside macOS/Qt 6.11.1 — no Windows or Linux run; and the keyboard map (`C` clear, `E` eraser, `1..9` presets) is deliberately still live during a lesson, since the issue's rule is about what is *touched* on the board.

<details><summary>Where the gate sits, what it does not cover, and the probe used as evidence</summary>

**Where the gate sits.** At the input layer, never at the verbs. `Lab.runFlow()` performs each task through `solve()`, i.e. through the lab's own `flowActions()`, so the headless verification run cannot be locked out — that is why `lab_check_electronics-101` is green rather than merely still passing.

`BoardInput.pressAt` checks `granted(hit)` immediately after the hit test, before every branch, so an empty-board click, the eraser, a wire tap and a pad all refuse together. A pad or a wire is never granted even for an allowed part: the circuit is what the lesson is teaching, and rewiring it mid-sentence is the thing this exists to stop. The camera is never gated — looking around is not touching.

**Not covered, on purpose.** The reserved key map. `C`, `E`, `V`, `Del` and the preset digits still act during a lesson, exactly as before this change; `LabKeys`' own doc now says so instead of claiming "a flow never locks the lab". The card's `h`/`l`/Enter *are* gated, because they run through `PartCard.keys`.

**The probe.** Both `Done when` lines above come from one `clayrender` run against `labs/electronics-101/Sandbox.qml` with `--paused`, so the sim clock never ticks and only the new immediate `check()` can end the task. The probe runs inside `--wait-for` (evaluated per frame) and refuses to click until `view3d.mapFrom3DScene` and `stage.worldAt` round-trip to within 0.3 world units of the part it is aiming at, so a camera still gliding cannot make it click the wrong cell. It then drives `boardMouse.clickAt()` — the same entry point a real mouse press takes.

**Follow-up noticed, not done.** `switchit` in the logic flow narrates "select it and pick another function" while its own demo does the switching; under the lock the learner cannot. It reads as description rather than instruction, so the wording was left alone.

</details>

Closes #221
