### PR TITLE
Markers on the parts a lesson names, while it names them

### DIFF
--- a/labs/electronics-101/Sandbox.qml
+++ b/labs/electronics-101/Sandbox.qml
@@ -1230,13 +1230,16 @@ Item {
     }
 
     // Whether the running step keeps the camera on its subject: every task
-    // step (the learner has to find the thing), and the steps whose line
-    // walks through the parts of one thing.
+    // step (the learner has to find the thing), every step that raises marks
+    // (the ring is on the board, so a portrait of the teacher shows none of
+    // it), and the steps whose line walks through the parts of one thing.
     readonly property var heldSteps: ["meet", "chip"]
     function holdStep() {
         const f = root.currentFlow
         if (!f || !f.step) return false
-        return f.step.task !== null || root.heldSteps.indexOf(f.step.key) >= 0
+        return f.step.task !== null
+            || (f.step.mark && f.step.mark.length > 0)
+            || root.heldSteps.indexOf(f.step.key) >= 0
     }
 
     // The scene a step opens, for the establishing shot: a step whose demo
@@ -1404,14 +1407,44 @@ Item {
         return Qt.resolvedUrl("voice/en/" + s.key + "-" + sayIndex + ".m4a")
     }
 
-    // What a script's `*point at NAME*` means in THIS scene. The parts are
-    // model data, not named nodes, so the lookup answers from the model - the
-    // same authority subjectOf() uses - rather than from a scene walk.
+    // What a script's `*point at NAME*` - and a step's `mark:` list - means in
+    // THIS scene. The parts are model data, not named nodes, so the lookup
+    // answers from the model - the same authority subjectOf() uses - rather
+    // than from a scene walk.
+    //
+    // Two spellings on purpose. A script is prose ("the resistor"), so it
+    // reads that way; a `mark:` list is authoring, written once and shown in
+    // both languages, so it is the bare type ("resistor"). Both land on the
+    // same part.
+    readonly property var scriptTypes: ({
+        "the battery": "battery", "the cell": "battery", "battery": "battery",
+        "the LED": "led", "led": "led",
+        "the resistor": "resistor", "resistor": "resistor",
+        "the switch": "switch", "switch": "switch",
+        "the transistor": "transistor", "transistor": "transistor",
+        "the gate": "gate", "gate": "gate"
+    })
+    // The transistor's legs, by the terminal index circuit.js gives them.
+    // This is what "or sub-parts" means here: a mark can land on one pad of
+    // one part, which is the whole of "collector on the left".
+    readonly property var scriptLegs: ({
+        "the collector": 0, "collector": 0,
+        "the base": 1, "base": 1,
+        "the emitter": 2, "emitter": 2
+    })
     function scriptTarget(name) {
         root.elemRev
-        const type = ({ "the battery": "battery", "the cell": "battery",
-                        "the LED": "led", "the resistor": "resistor",
-                        "the switch": "switch" })[name]
+        const leg = root.scriptLegs[name]
+        if (leg !== undefined) {
+            const qs = root.idsOfType("transistor")
+            if (!qs.length)
+                return null
+            // The pad itself, lifted a little so a ring sits on the leg
+            // rather than in the board under it.
+            const p = root.terminalPos(qs[0], leg)
+            return Qt.vector3d(p.x, 1.5, p.z)
+        }
+        const type = root.scriptTypes[name]
         if (!type)
             return null
         const ids = root.idsOfType(type)
@@ -1420,6 +1453,17 @@ Item {
         const e = root.elemAt(ids[0])
         // A hand's breadth above the board, as subjectOf() aims.
         return e ? Qt.vector3d(root.cellX(e.col), 1.5, root.cellZ(e.row)) : null
+    }
+
+    // What a mark's ring is captioned with, in the reader's language. The
+    // names above are authoring tokens - identical in EN and DE, which is what
+    // lets the cross-language lint compare two versions of a script - so the
+    // caption cannot come from the name itself.
+    function markLabel(name) {
+        if (root.scriptLegs[name] !== undefined)
+            return LabLang.t("npn." + name.replace("the ", ""))
+        const type = root.scriptTypes[name]
+        return type ? LabLang.t("part." + type) : ""
     }
 
     // Which lesson `T` and the chip offer. Two flows, one key: a lab with a
@@ -1636,6 +1680,11 @@ Item {
             scriptOf: (i) => root.flowScript(i)
             scriptVoiceOf: (i, sayIndex) => root.flowScriptVoice(i, sayIndex)
             scriptResolve: (name) => root.scriptTarget(name)
+            // The eye's half of a line that names things: the step says which
+            // parts it is about, the guide resolves them and the MarkLayer
+            // below rings them for as long as the line lasts.
+            marks: root.currentFlow ? root.currentFlow.marks : []
+            markLabelOf: (n) => root.markLabel(n)
             director: director
             sceneOf: (i) => root.flowScene(i)
             scenePointsOf: (i) => root.cellExtent(root.elements)
@@ -1907,6 +1956,10 @@ Item {
         }
         FlowStep {
             key: "wire"
+            // "cell to switch, switch to LED, LED through the resistor and
+            // back to the cell" - four parts named in one breath, and until
+            // now four things to find by ear.
+            mark: ["battery", "switch", "led", "resistor"]
             demo: [["let", "sw", "addPart", "switch", 12, 2],
                    ["select", -1], ["frame", "setup"],
                    ["wire", "bat", 1, "sw", 0],
@@ -1950,6 +2003,10 @@ Item {
 
         FlowStep {
             key: "meet"
+            // "collector on the left, emitter on the right, base facing you":
+            // three sub-parts of one part, each ringed and captioned in the
+            // reader's language while the line names them.
+            mark: ["collector", "base", "emitter"]
             demo: [["scenario", "transistor"], ["showValues", false],
                    ["setInputs", 0], ["frame", "setup"]]
         }
@@ -2656,6 +2713,24 @@ Item {
             if (i === null || i === undefined) return "?"
             return root.fmtA(Math.abs(i))
         }
+    }
+
+    // --- the parts the lesson is naming right now --------------------------
+    // Over the readings, because a mark is deixis and a reading is data: while
+    // the professor says "the battery, the switch, the LED and the resistor,
+    // one loop", the ring is the sentence and the numbers are background.
+    // Same keep-out as the readings - a ring drawn on a coat marks the coat.
+    // NOT `id: marks` - the type has a property of that name, and an id that
+    // shadows it turns `marks: ...` into an assignment to itself (the
+    // WatchChip/OrbitInput3D trap).
+    MarkLayer {
+        id: markLayer
+        objectName: "markLayer"
+        anchors.fill: parent
+        view: view3d
+        camera: rig.camera
+        marks: guide.markPoints
+        keepOut: overlay.keepOut
     }
 
     // --- selection card (what is selected, what it reads, what you can do) -

--- a/labs/kits/professor/FlowGuide.qml
+++ b/labs/kits/professor/FlowGuide.qml
@@ -195,6 +195,48 @@ Item {
     property var scriptVoiceOf: null
 
     /*!
+        The names of the parts the CURRENT step's line is about, as the lab
+        spells them: bind it to the flow's own \c marks (from
+        \c {FlowStep.mark}). Each is resolved the way a script's
+        \c{*point at NAME*} target is - through \l scriptResolve, else the
+        \l scriptTargets walk - and comes out in \l markPoints for a
+        \c MarkLayer to draw.
+
+        \code
+        marks: root.currentFlow ? root.currentFlow.marks : []
+        \endcode
+
+        Ignored on a step that carries a \l scriptOf script: that step's
+        marks are its own \c{*mark ...*} cues, which can raise a different
+        set for every line.
+    */
+    property var marks: []
+
+    /*!
+        Optional: given a mark's name, what to write under its ring in the
+        reader's language, or "" for a ring with no caption.
+
+        \code
+        markLabelOf: (n) => LabLang.t("npn." + n)
+        \endcode
+
+        The names in \l marks and in a script's \c{*mark ...*} cue are
+        authoring tokens - they are the same in every language, which is what
+        lets the cross-language lint compare them. Only the lab knows what
+        "collector" is called in German, so the caption comes from here.
+    */
+    property var markLabelOf: null
+
+    /*!
+        \readonly The marks to draw right now, each \c {{at, label}} - the
+        script's while a directed step is running, the step's \l marks
+        otherwise. Hand it straight to a \c MarkLayer.
+    */
+    readonly property var markPoints: root._directed
+        ? root._labelled(_perf.markNames, _perf.marks)
+        : root._resolveMarks(root.marks)
+
+    /*!
         The camera's director, a \c CameraDirector from the lab kernel. Null
         leaves the camera to the lab.
 
@@ -274,6 +316,39 @@ Item {
         return _perf._resolve(name)
     }
 
+    // Whether the running step is directed by a script. Decided when the step
+    // starts rather than derived, so a script that has finished speaking does
+    // not hand the step's own mark field back mid-step.
+    property bool _directed: false
+
+    function _markLabel(name) {
+        if (typeof root.markLabelOf !== "function" || !name)
+            return ""
+        const t = root.markLabelOf(name)
+        return (t === undefined || t === null) ? "" : "" + t
+    }
+
+    // Names -> [{at, label}], dropping the ones this scene cannot place.
+    function _resolveMarks(names) {
+        const out = []
+        const src = names || []
+        for (let i = 0; i < src.length; ++i) {
+            const pos = root._resolveCue(src[i])
+            if (pos) out.push({ at: pos, label: root._markLabel(src[i]) })
+        }
+        return out
+    }
+
+    // The same, for points the sequencer has already resolved.
+    function _labelled(names, points) {
+        const out = []
+        const pts = points || []
+        const ns = names || []
+        for (let i = 0; i < pts.length; ++i)
+            out.push({ at: pts[i], label: root._markLabel(i < ns.length ? ns[i] : "") })
+        return out
+    }
+
     // What the current step's camera should hold: its extent, else its look.
     function _extentNow() {
         const s = (typeof root.subjectOf === "function") ? root.subjectOf(root.step) : null
@@ -317,6 +392,7 @@ Item {
             _scene.stop()
             _perf.stop()
             _addressing = false
+            _directed = false
             root.professor.stopGesture()
             root.professor.vanish()
             if (root.director) root.director.release()
@@ -386,6 +462,7 @@ Item {
         // where to stand - but everything after landing belongs to the
         // script, not to the built-in beat.
         const script = root._scriptFor(root.step)
+        _directed = script !== ""
         if (script !== "") {
             if (stand && p.present) {
                 _pending = null

--- a/labs/kits/professor/README.md
+++ b/labs/kits/professor/README.md
@@ -227,6 +227,40 @@ directed steps. Measured with pre-rendered clips: the sequencer advances
 about 80 ms after the recording actually ends — the clip's real duration is
 the cue clock, not an estimate.
 
+### Marks — the eye's half of a sentence that names things
+
+"The battery, the switch, the LED and the resistor, one loop" asks the learner
+to find four things by ear. `FlowGuide` resolves the names and hands out the
+points; the kernel's `MarkLayer` rings them.
+
+```qml
+FlowGuide {
+    marks: root.currentFlow ? root.currentFlow.marks : []   // FlowStep.mark
+    markLabelOf: (n) => root.markLabel(n)                   // caption, localized
+}
+
+MarkLayer {
+    anchors.fill: parent
+    view: view3d; camera: rig.camera
+    marks: guide.markPoints
+    keepOut: overlay.keepOut       // a ring on the coat marks the coat
+}
+```
+
+Two sources, one drawing. A plain step names its parts in `FlowStep.mark` and
+they are marked for the whole step. A *directed* step names them per line, in
+its script's own `*mark ...*` cues, and each set lives for the length of the
+line that follows it — `guide.markPoints` follows whichever applies, and the
+step's `mark` field is ignored while a script is running.
+
+Names resolve through `scriptResolve` (else the `scriptTargets` walk), exactly
+as `*point at NAME*` does, so a name can be a whole part or a sub-part of one:
+electronics-101 answers "collector" with the transistor's first pad. They are
+authoring tokens, identical in every language — which is what lets the
+cross-language lint compare two versions of a script — so the caption under a
+ring comes from `markLabelOf` instead, and only the lab knows what "collector"
+is called in German.
+
 ## Traps
 
 **`height3d` is not the height it renders at.** It is `bodyHeight` on the

--- a/plugins/clay_character3d/Performance.qml
+++ b/plugins/clay_character3d/Performance.qml
@@ -54,6 +54,14 @@ import "scripting/performancescript.js" as Script
     \l skipped and \l errors are all readable from an inspector or a headless
     render, and \l debug narrates every cue to the console.
 
+    \b{Marks.} \c{*mark the collector*} - or \c{*mark the battery, the
+    switch*} - resolves its names the way \c{*point at*} resolves its target
+    and publishes the points in \l marks. Nothing here draws them: a
+    sequencer has no view, and the overlay that does belongs to whatever is
+    showing the scene. They live for the length of the line the cue precedes
+    and are dropped when it ends, which is the whole of the rule an author
+    has to hold: a marker says "this one, now", not "this one, still".
+
     \sa Character
 */
 Item {
@@ -182,6 +190,17 @@ Item {
         to be debugged without being watched.
     */
     readonly property var firedLog: _firedLog
+    /*!
+        The world points a \c{*mark ...*} cue currently raises, as
+        \c vector3d, resolved exactly as a point target is. Empty whenever
+        nothing is marked. Bind an overlay to it.
+    */
+    readonly property var marks: _marks
+    /*!
+        The names behind \l marks, in the same order and only the ones that
+        resolved - a name that did not is in \l skipped instead.
+    */
+    readonly property var markNames: _markNames
 
     /*! Emitted after the last cue of a script. Not emitted by \l stop(). */
     signal finished()
@@ -278,6 +297,7 @@ Item {
         _stopTimers()
         _running = false
         _currentCue = ""
+        _clearMarks()
         // Whichever of the three the performer calls it.
         if (!_call("stopSpeaking") && !_call("hush"))
             _call("quiet")
@@ -333,6 +353,12 @@ Item {
     property var _skipped: []
     property var _firedLog: []
     property var _handlers: ({})
+    property var _marks: []
+    property var _markNames: []
+    // "" nothing marked, "armed" raised and waiting for its line, "showing"
+    // that line is being spoken. The state is what makes "for the length of
+    // the line" a rule rather than a guess about timing.
+    property string _markState: ""
     property var _warned: ({})
     property bool _running: false
     property bool _done: false
@@ -379,6 +405,36 @@ Item {
         return true
     }
 
+    function _clearMarks() {
+        if (_marks.length === 0 && _markNames.length === 0 && _markState === "")
+            return
+        _marks = []
+        _markNames = []
+        _markState = ""
+    }
+
+    // Raise the marks a cue asks for. Every name goes through the point
+    // resolver, so a scene that can be pointed at can be marked; a name that
+    // does not resolve is skipped and the rest of the list still shows.
+    function _mark(cue) {
+        const names = (cue.targets && cue.targets.length) ? cue.targets : [cue.target]
+        const pts = []
+        const kept = []
+        for (let i = 0; i < names.length; ++i) {
+            const pos = _resolve(names[i])
+            if (!pos) {
+                _skip({ type: "mark", target: names[i] },
+                      "target '" + names[i] + "' did not resolve")
+                continue
+            }
+            pts.push(pos)
+            kept.push(names[i])
+        }
+        _marks = pts
+        _markNames = kept
+        _markState = pts.length > 0 ? "armed" : ""
+    }
+
     function _skip(cue, reason) {
         _skipped = _skipped.concat([{ cue: Script.describe(cue), reason: reason }])
         const key = Script.describe(cue) + "|" + reason
@@ -399,10 +455,15 @@ Item {
     function _play() {
         if (!_running)
             return
+        // The line the marks belong to is over the moment the cue after it
+        // starts - that is the one edge "for the length of the line" has.
+        if (_markState === "showing")
+            _clearMarks()
         if (_next >= _cues.length) {
             _running = false
             _done = true
             _currentCue = ""
+            _clearMarks()
             if (debug)
                 console.log("[perform] " + _elapsed() + "ms done, "
                             + _cues.length + " cues")
@@ -453,6 +514,12 @@ Item {
             break
         case "rest":
             if (!_call("stopGesture")) _skip(cue, "performer has no stopGesture()")
+            _advanceLater()
+            break
+        case "mark":
+            // Nothing is asked of the performer: a mark is drawn by whatever
+            // is showing the scene, and the sequencer only says what and when.
+            _mark(cue)
             _advanceLater()
             break
         case "pause":
@@ -572,6 +639,9 @@ Item {
             _advanceLater()
             return
         }
+        // This is the line the marks were raised for.
+        if (_markState === "armed")
+            _markState = "showing"
         const clip = _clipFor(_sayIndex)
         _sayIndex++
         const timed = cue.hintMs !== null && cue.hintMs !== undefined

--- a/plugins/clay_character3d/README.md
+++ b/plugins/clay_character3d/README.md
@@ -614,6 +614,7 @@ outside a `*...*` is spoken.
 | `*thumbs up*` | Approval gesture | `thumbsUp()` |
 | `*gesticulate*` | Talking hands on | `gesticulate()` |
 | `*rest*` | Drops any gesture | `stopGesture()` |
+| `*mark NAME*` / `*mark A, B, C*` | Raises markers on the named things for the length of the line that follows | none - the points come out in `marks` |
 | `*pause 800ms*` `*pause 2s*` `*pause 1.5s*` | Consumes that much time | - |
 | anything else | A reported error in strict mode | - |
 
@@ -622,6 +623,35 @@ and resolved against the scene - there is no second naming scheme. It may
 contain spaces: `*point at the big red battery*`. `viewer` is the one reserved
 name and means the camera. A duration is a number plus a unit, `ms` or `s`,
 both required; `*pause 800*` is an error rather than a guess.
+
+`*mark*` is the one directive that takes several targets, comma separated,
+because naming a group is exactly when it earns its keep:
+`*mark the battery, the switch, the LED* Four parts, one loop.`
+
+### Marks
+
+A line that names things - "collector on the left, emitter on the right, base
+facing you" - asks the eye to find each of them by ear. `*mark ...*` resolves
+its names the way `*point at*` resolves its target and publishes the world
+points in `marks`; `markNames` holds the names that resolved, in the same
+order. A name that does not resolve is skipped and recorded, and the rest of
+the list still marks.
+
+Nothing here draws them. A sequencer has no view, so the points go to whatever
+is showing the scene - `Clayground.Lab`'s `MarkLayer` is the overlay the labs
+use, and a lab's own is one binding away.
+
+The lifetime is the whole of the rule an author has to hold: a mark set is
+raised by its cue, lives for the length of the *one* line that follows it, and
+is gone by the time the next cue starts. `stop()` and the end of the script
+clear it too. A marker says "this one, now", not "this one, still" - so a
+sentence that keeps a mark up needs its own `*mark*`:
+
+```
+*mark the collector* Collector on the left.
+*mark the emitter* Emitter on the right.
+*mark the base* And the base, facing you.
+```
 
 ### Time hints
 
@@ -689,6 +719,7 @@ A script is verified by reading state, not by watching it.
 | `errors` | Parse errors of the last `play()`, each `{at, directive, message}` |
 | `skipped` | Cues that could not be carried out, each `{cue, reason}` - an unresolved target, a missing verb, a handler that threw |
 | `firedLog` | Every cue that fired, each `{ms, cue}`, ms measured from `play()` |
+| `marks` / `markNames` | The world points a `*mark ...*` cue currently raises, and the names behind them. Empty whenever nothing is marked |
 | `finished()` | Emitted after the last cue |
 | `customCue(verb, arg)` | Emitted for a custom cue with no registered handler |
 

--- a/plugins/clay_character3d/scripting/performancescript.js
+++ b/plugins/clay_character3d/scripting/performancescript.js
@@ -66,7 +66,12 @@ var TARGETED = {
     "present": "present",
     "show": "present",
     "look at": "look",
-    "face": "face"
+    "face": "face",
+    // Markers on the things a line names, for as long as that line lasts.
+    // Several at once, comma separated - "the battery, the switch, the LED" -
+    // because naming a group is exactly when a marker earns its keep, and a
+    // sentence that lists four parts is one sentence.
+    "mark": "mark"
 }
 
 // The one reserved target: wherever the camera is. Case-insensitive, and
@@ -82,6 +87,19 @@ var DURATION_RE = /^(\d+(?:\.\d+)?)\s*(ms|s)$/i
 // the last word - is text. The rule stays this blunt on purpose: an author
 // should be able to tell hint from prose without consulting the grammar.
 var HINT_RE = /\s\((\d+(?:\.\d+)?)\s*(ms|s)\)$/i
+
+// "a, b ,c" -> ["a", "b", "c"]. Empty entries are dropped rather than
+// resolved: a trailing comma is a typo, not a target called "".
+function _splitTargets(text) {
+    var out = []
+    var parts = ("" + text).split(",")
+    for (var i = 0; i < parts.length; ++i) {
+        var t = parts[i].trim()
+        if (t !== "")
+            out.push(t)
+    }
+    return out
+}
 
 function _toMs(value, unit) {
     var n = parseFloat(value)
@@ -131,6 +149,15 @@ function _directive(norm, at, extraVerbs) {
             var target = norm.substring(verb.length + 1).trim()
             if (target.toLowerCase() === VIEWER)
                 target = VIEWER
+            if (TARGETED[verb] === "mark") {
+                var names = _splitTargets(target)
+                if (names.length === 0)
+                    return { error: "'mark' needs a target name" }
+                // `target` stays the canonical spelling of the whole list, so
+                // describe() and the cross-language lint compare one string.
+                return { cue: { type: "mark", target: names.join(", "),
+                                targets: names, at: at } }
+            }
             return { cue: { type: TARGETED[verb], target: target, at: at } }
         }
     }
@@ -286,6 +313,8 @@ function describe(cue) {
         return "look at " + cue.target
     case "face":
         return "face " + cue.target
+    case "mark":
+        return "mark " + cue.target
     case "thumbsUp":
         return "thumbs up"
     case "gesticulate":
@@ -315,7 +344,8 @@ function _isDirective(cue) { return cue.type !== "say" }
 function _argOf(cue) {
     switch (cue.type) {
     case "emotion": return cue.value
-    case "point": case "present": case "look": case "face": return cue.target
+    case "point": case "present": case "look": case "face": case "mark":
+        return cue.target
     case "pause": return "" + cue.ms
     case "custom": return cue.arg
     }

--- a/plugins/clay_character3d/scripting/performancescript.test.js
+++ b/plugins/clay_character3d/scripting/performancescript.test.js
@@ -74,6 +74,40 @@ section('directives: targets')
        'face/look')
 }
 
+section('directives: mark')
+{
+    const m = cues('*mark the collector*')[0]
+    eq('mark type', m.type, 'mark')
+    eq('one target', m.target, 'the collector')
+    eq('and it is a list of one', m.targets.join('|'), 'the collector')
+    eq('mark describes itself', shape('*mark the collector*'), 'mark the collector')
+
+    const g = cues('*mark the battery, the switch, the LED*')[0]
+    eq('a list splits', g.targets.join('|'), 'the battery|the switch|the LED')
+    eq('the description keeps the whole list',
+       P.describe(g), 'mark the battery, the switch, the LED')
+    eq('spacing round the commas is normalized',
+       cues('*mark a ,b ,  c*')[0].target, 'a, b, c')
+    eq('a trailing comma is not a target',
+       cues('*mark the battery,*')[0].targets.length, 1)
+    eq('a bare mark is an error', errs('*mark*').length, 1)
+    eq('so is a mark of nothing but commas', errs('*mark , ,*').length, 1)
+    eq('mark is not a point',
+       cues('*mark battery*')[0].type + '/' + cues('*point at battery*')[0].type,
+       'mark/point')
+
+    // The lint's job: a translator may rewrite the sentence, never the list.
+    eq('the same list in two languages is in sync',
+       P.lint('*mark the battery, the switch* One loop.',
+              '*mark the battery, the switch* Ein Kreis.').length, 0)
+    eq('a dropped name is caught',
+       P.lint('*mark the battery, the switch* One loop.',
+              '*mark the battery* Ein Kreis.').length, 1)
+    eq('a reordered list is caught',
+       P.lint('*mark the battery, the switch* One loop.',
+              '*mark the switch, the battery* Ein Kreis.').length, 1)
+}
+
 section('directives: gestures')
 {
     eq('thumbs up', shape('*thumbs up*'), 'thumbs up')

--- a/plugins/clay_character3d/tests/qml/tst_marks.qml
+++ b/plugins/clay_character3d/tests/qml/tst_marks.qml
@@ -1,0 +1,138 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+//
+// The *mark ...* cue, end to end through the sequencer.
+//
+// The parser suite next door pins the grammar; what cannot be checked without
+// a running Performance is the LIFETIME, and that is the whole of the feature:
+// a mark is raised by its cue, lives for the line that follows it, and is gone
+// by the time the next cue starts. Getting that wrong leaves a ring on a part
+// the lesson has moved past - which reads as a bug in the lesson, not in the
+// sequencer, and is why it is stated here rather than left to a screenshot.
+//
+// `import "../.."` picks up the plugin's QML directly: no built module, no
+// window, no GPU. The performer is a stub, as everywhere else in this suite.
+
+import QtQuick
+import QtTest
+import "../.."
+
+Item {
+    id: root
+    width: 50; height: 50
+
+    // Speaks by being told to, and stops when the sequencer's time hint runs
+    // out. Nothing here has to do anything with a mark - a mark is not an act
+    // of the performer's.
+    component Stub: QtObject {
+        property bool talking: false
+        property var lines: []
+        function tell(text, clip) { lines = lines.concat([text]); talking = true }
+        function quiet() { talking = false }
+        function stopGesture() {}
+        function pointAt(p) {}
+    }
+
+    Stub { id: stub }
+
+    Performance {
+        id: perf
+        performer: stub
+        spoken: false
+        // The same seam a lab uses: names are the scene's business, not the
+        // sequencer's. "nowhere" is deliberately unplaceable.
+        resolveTarget: (name) => name === "alpha" ? Qt.vector3d(1, 0, 0)
+                              : name === "beta"  ? Qt.vector3d(2, 0, 0)
+                              : name === "gamma" ? Qt.vector3d(3, 0, 0)
+                              : null
+    }
+
+    TestCase {
+        name: "PerformanceMarks"
+        when: windowShown
+
+        function init() {
+            perf.stop()
+            stub.lines = []
+        }
+
+        function test_nothing_is_marked_before_a_script() {
+            compare(perf.marks.length, 0)
+            compare(perf.markNames.length, 0)
+        }
+
+        function test_a_cue_raises_its_targets_resolved() {
+            verify(perf.play("*mark alpha, beta* One. (2s) *rest* Two. (60ms)"))
+            tryCompare(perf, "currentCue", "say 'One.' (2000ms)")
+            compare(perf.markNames.join(","), "alpha,beta")
+            compare(perf.marks.length, 2)
+            compare(perf.marks[0].x, 1)
+            compare(perf.marks[1].x, 2)
+        }
+
+        // The lifetime rule, stated: up for that line, down for the next cue.
+        function test_marks_last_exactly_one_line() {
+            verify(perf.play("*mark alpha* One. (600ms) *mark beta* Two. (600ms)"))
+            tryCompare(perf, "currentCue", "say 'One.' (600ms)")
+            compare(perf.markNames.join(","), "alpha")
+            tryCompare(perf, "currentCue", "say 'Two.' (600ms)", 4000)
+            compare(perf.markNames.join(","), "beta",
+                    "the second cue replaced the first line's mark")
+            tryCompare(perf, "done", true, 4000)
+            compare(perf.marks.length, 0, "and the last line's mark went with it")
+        }
+
+        function test_a_script_that_ends_marked_still_clears() {
+            verify(perf.play("*mark alpha*"))
+            tryCompare(perf, "done", true, 4000)
+            compare(perf.marks.length, 0)
+        }
+
+        function test_stop_clears_the_marks() {
+            verify(perf.play("*mark alpha, beta* One. (4s)"))
+            tryCompare(perf, "currentCue", "say 'One.' (4000ms)")
+            compare(perf.marks.length, 2)
+            perf.stop()
+            compare(perf.marks.length, 0)
+            compare(perf.markNames.length, 0)
+        }
+
+        // A name the scene cannot place must not take the rest of the list
+        // with it, and must not be drawn at the origin.
+        function test_an_unresolved_name_is_skipped_not_fatal() {
+            verify(perf.play("*mark alpha, nowhere, gamma* One. (2s)"))
+            tryCompare(perf, "currentCue", "say 'One.' (2000ms)")
+            compare(perf.markNames.join(","), "alpha,gamma")
+            compare(perf.marks.length, 2)
+            compare(perf.skipped.length, 1)
+            compare(perf.skipped[0].cue, "mark nowhere")
+        }
+
+        function test_a_mark_of_nothing_placeable_marks_nothing() {
+            verify(perf.play("*mark nowhere* One. (600ms)"))
+            tryCompare(perf, "done", true, 4000)
+            compare(perf.marks.length, 0)
+            compare(perf.skipped.length, 1)
+        }
+
+        // The cue reaches a listener the same way every other one does, which
+        // is what lets a guide react to it without polling.
+        function test_the_cue_is_reported_like_any_other() {
+            let seen = ""
+            const c = (type, arg) => { if (type === "mark") seen = arg }
+            perf.cueFired.connect(c)
+            verify(perf.play("*mark alpha, beta* One. (600ms)"))
+            tryCompare(perf, "done", true, 4000)
+            perf.cueFired.disconnect(c)
+            compare(seen, "alpha, beta")
+        }
+
+        // Marks are not an act of the performer's: a stub with no mark method
+        // of any kind is not recorded as unable to do one.
+        function test_the_performer_is_never_asked_to_mark() {
+            verify(perf.play("*mark alpha* One. (600ms)"))
+            tryCompare(perf, "done", true, 4000)
+            compare(perf.skipped.length, 0)
+            compare(stub.lines.join("|"), "One.")
+        }
+    }
+}

--- a/plugins/clay_lab/CMakeLists.txt
+++ b/plugins/clay_lab/CMakeLists.txt
@@ -40,6 +40,7 @@ clay_plugin( Lab
         Narrator.qml
         FlowChip.qml
         WorldLabel.qml
+        MarkLayer.qml
         SelectionFrame3D.qml
         HintJump.qml
         CardFocusRing.qml

--- a/plugins/clay_lab/Flow.qml
+++ b/plugins/clay_lab/Flow.qml
@@ -176,6 +176,18 @@ Item {
     readonly property string title: titleKey === "" ? "" : LabLang.t(titleKey)
 
     /*!
+        \qmlproperty var Flow::marks
+        \readonly
+        \brief The active step's \l {FlowStep::mark} names; empty when idle.
+
+        One binding for the lab: hand it to whatever resolves and draws the
+        marks (the professor kit's \c FlowGuide, or a \l MarkLayer
+        directly). It empties itself when the flow stops, so a mark cannot
+        outlive the lesson.
+    */
+    readonly property var marks: (step === null || !step.mark) ? [] : step.mark
+
+    /*!
         \qmlproperty string Flow::narration
         \readonly
         \brief The active step's text in the current language.

--- a/plugins/clay_lab/FlowStep.qml
+++ b/plugins/clay_lab/FlowStep.qml
@@ -92,6 +92,28 @@ QtObject {
     property var view: null
 
     /*!
+        \qmlproperty var FlowStep::mark
+        \brief Parts (or sub-parts) this step's line names, as a list of names.
+
+        The eye's half of a spoken sentence. A line that says "the battery,
+        the switch, the LED and the resistor, one loop" asks the learner to
+        find four things by ear; \c {mark: ["battery", "switch", "led",
+        "resistor"]} rings all four on the model while the line lasts, and
+        the marks go with the step.
+
+        The names are the lab's own - resolved exactly as a performance
+        script's \c{*point at NAME*} target is, by whatever the presenter's
+        guide was given as a resolver - so they are language-neutral
+        authoring tokens, not display text. Nothing here draws them: a lab
+        binds them to a \l MarkLayer.
+
+        A directed step (one with a performance script) ignores this field:
+        its marks come from the script's own \c{*mark ...*} cues, which can
+        raise a different set per line.
+    */
+    property var mark: []
+
+    /*!
         \qmlproperty var FlowStep::expect
         \brief Optional predicate asserted after the step, for headless checks.
     */

--- a/plugins/clay_lab/MarkLayer.qml
+++ b/plugins/clay_lab/MarkLayer.qml
@@ -1,0 +1,240 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Clayground.Lab
+
+/*!
+    \qmltype MarkLayer
+    \inqmlmodule Clayground.Lab
+    \brief Rings on the world points something is naming right now.
+
+    A presenter saying "collector on the left, emitter on the right, base
+    facing you" is asking the eye to find three things by ear. This is the
+    other half of that sentence: a ring on each of them, up while the line
+    lasts and gone afterwards.
+
+    It draws \l marks and nothing else. Where they come from is the caller's
+    business - a \c{*mark ...*} cue in a performance script
+    (\c Performance.marks), a \c {FlowStep.mark} field, or a lab pointing at
+    its own selection. Each entry is a world point, either a \c vector3d or
+    \c {{ at: vector3d, label: string }}; a label draws a small chip under
+    the ring, and no label draws the ring alone.
+
+    Screen space over the 3D scene, like \l WorldLabel and \l BoardOverlay:
+    put it in the same parent as the \c View3D, not inside it.
+
+    \qml
+    import Clayground.Lab
+
+    MarkLayer {
+        anchors.fill: parent
+        view: view3d
+        camera: rig.camera
+        marks: guide.markPoints
+        keepOut: root.presenterBox
+    }
+    \endqml
+
+    \note The projection lists \c camera.scenePosition and
+    \c camera.sceneRotation as explicit dependencies. Without them the marks
+    freeze where the camera first saw them - invisible until the rig moves,
+    which is the one thing a mark has to survive.
+
+    \sa WorldLabel, BoardOverlay, Flow, FlowStep
+*/
+Item {
+    id: root
+
+    /*!
+        \qmlproperty var MarkLayer::view
+        \brief The \c View3D to project through.
+
+        \c var rather than \c View3D on purpose: the kernel should not import
+        QtQuick3D to park a ring on a pixel.
+    */
+    property var view: null
+
+    /*! \qmlproperty var MarkLayer::camera \brief The camera the \l view renders with. */
+    property var camera: null
+
+    /*!
+        \qmlproperty var MarkLayer::marks
+        \brief What to ring: world points, each a \c vector3d or \c {{at, label}}.
+
+        Empty draws nothing. Replacing the list is the whole of the API -
+        there is no add/remove, because a mark set belongs to one sentence
+        and outliving it is the failure mode.
+    */
+    property var marks: []
+
+    /*!
+        \qmlproperty var MarkLayer::keepOut
+        \brief A screen rectangle (\c {{x, y, width, height}}) no mark is drawn
+               into, or null.
+
+        Same rule and the same shape as \l {BoardOverlay::keepOut}. A ring is
+        screen space over a 3D scene, so nothing depth-tests it against a
+        presenter standing in front of the part: a ring drawn on the coat
+        marks the coat. A mark whose point falls inside the box fades out
+        for as long as it does.
+    */
+    property var keepOut: null
+
+    /*! \qmlproperty color MarkLayer::tone \brief The ring colour. */
+    property color tone: LabTheme.highlight
+
+    /*! \qmlproperty real MarkLayer::ringSize \brief Ring diameter at rest, in px. */
+    property real ringSize: LabTheme.px(34)
+
+    /*!
+        \qmlproperty int MarkLayer::pulseMs
+        \brief Period of the halo that expands out of each ring; 0 draws none.
+
+        The halo is what makes a ring read as "this one, now" rather than as
+        another piece of chrome. It is decoration, so it is the first thing a
+        lab turns off.
+    */
+    property int pulseMs: 1400
+
+    /*! \qmlproperty int MarkLayer::count \readonly \brief How many marks are up. */
+    readonly property int count: _points.length
+
+    /*!
+        \qmlmethod var MarkLayer::screenOf(int i)
+        \brief Where mark \a i lands, as \c {{x, y, z}}; \c z <= 0 is behind the camera.
+
+        The verification seam: a claim about a mark is checked by asking
+        where it is, not by looking at a picture.
+    */
+    function screenOf(i) {
+        if (i < 0 || i >= _points.length) return Qt.vector3d(0, 0, 0)
+        return _project(_points[i].at)
+    }
+
+    /*! \qmlmethod bool MarkLayer::clear(real sx, real sy) \brief Is this screen point outside \l keepOut? */
+    function clear(sx, sy) {
+        const k = root.keepOut
+        if (!k) return true
+        return sx < k.x || sx > k.x + k.width || sy < k.y || sy > k.y + k.height
+    }
+
+    // Both accepted spellings normalized to one: { at, label }. Entries
+    // without a usable point are dropped here rather than drawn at the origin,
+    // which is what an unresolved name used to look like on screen.
+    readonly property var _points: {
+        const out = []
+        const src = root.marks || []
+        for (let i = 0; i < src.length; ++i) {
+            const m = src[i]
+            if (!m) continue
+            const at = (m.at !== undefined) ? m.at : m
+            if (!at || at.x === undefined) continue
+            out.push({ at: at, label: (m.label === undefined || m.label === null) ? "" : "" + m.label })
+        }
+        return out
+    }
+
+    function _project(p) {
+        if (!view || !p) return Qt.vector3d(0, 0, 0)
+        return view.mapFrom3DScene(p)
+    }
+
+    Repeater {
+        model: root._points
+
+        Item {
+            id: mark
+            // Named so a headless render can pick the marks out of the
+            // overlay without counting anonymous children.
+            objectName: "mark"
+            required property var modelData
+            required property int index
+
+            readonly property var screenAt: {
+                // The dependencies that make a mark survive the camera moving.
+                if (!root.camera) return Qt.vector3d(0, 0, 0)
+                root.camera.scenePosition; root.camera.sceneRotation
+                return root._project(mark.modelData.at)
+            }
+            readonly property bool shown: screenAt.z > 0
+                                          && root.clear(screenAt.x, screenAt.y)
+
+            x: screenAt.x
+            y: screenAt.y
+            width: 0
+            height: 0
+            visible: opacity > 0.001
+            opacity: shown ? 1 : 0
+            Behavior on opacity { NumberAnimation { duration: 160 } }
+
+            // The halo: one ring expanding out of the mark and fading, so a
+            // mark that comes up while the reader is looking elsewhere still
+            // catches the eye.
+            Rectangle {
+                id: halo
+                anchors.centerIn: parent
+                width: root.ringSize; height: width
+                radius: width / 2
+                color: "transparent"
+                border.color: root.tone
+                border.width: Math.max(1, LabTheme.px(2))
+                visible: root.pulseMs > 0 && mark.shown
+                SequentialAnimation {
+                    running: halo.visible
+                    loops: Animation.Infinite
+                    ParallelAnimation {
+                        NumberAnimation { target: halo; property: "scale"
+                                          from: 1.0; to: 2.1
+                                          duration: root.pulseMs
+                                          easing.type: Easing.OutCubic }
+                        NumberAnimation { target: halo; property: "opacity"
+                                          from: 0.55; to: 0
+                                          duration: root.pulseMs
+                                          easing.type: Easing.OutCubic }
+                    }
+                }
+            }
+
+            Rectangle {
+                id: ring
+                anchors.centerIn: parent
+                width: root.ringSize; height: width
+                radius: width / 2
+                color: "transparent"
+                border.color: root.tone
+                border.width: Math.max(2, LabTheme.px(3))
+                scale: mark.shown ? 1 : 0.6
+                Behavior on scale { NumberAnimation { duration: 220; easing.type: Easing.OutBack } }
+            }
+
+            // The name, when the caller supplies one - "collector" under the
+            // ring on the collector. Under, not over: the ring is on the part
+            // and the chip must not cover what it is naming.
+            Rectangle {
+                id: chip
+                visible: mark.modelData.label !== ""
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.top: ring.bottom
+                anchors.topMargin: LabTheme.px(4)
+                width: chipText.implicitWidth + LabTheme.spaceL
+                height: chipText.implicitHeight + LabTheme.spaceS
+                radius: LabTheme.px(4)
+                color: LabTheme.panel
+                border.color: root.tone
+                border.width: Math.max(1, LabTheme.px(1.5))
+                opacity: 0.96
+                Text {
+                    id: chipText
+                    anchors.centerIn: parent
+                    text: mark.modelData.label
+                    color: LabTheme.ink
+                    font.pixelSize: LabTheme.fontSmall
+                    font.bold: true
+                    font.family: LabTheme.monoFont
+                }
+            }
+        }
+    }
+}

--- a/plugins/clay_lab/README.md
+++ b/plugins/clay_lab/README.md
@@ -127,6 +127,10 @@ Everything below was hand-rolled in two labs before it moved here.
   plot full, the limit read off the monitor), **WatchMark** the dot the
   object then wears in the world, in its curve's colour.
 - **WorldLabel** — 2D paper chip pinned to a 3D point.
+- **MarkLayer** — rings on the world points something is naming right
+  now, optionally captioned. Fed by a `FlowStep.mark` list or a
+  performance script's `*mark ...*` cue; `keepOut` keeps a ring off a
+  presenter standing in front of the part it marks.
 - **SelectionFrame3D** — the shared hover/select language on the work
   surface (thin outline hovering, full frame plus facing mark selected).
   Used by the circuit kit; note that its lift is measured from the object,

--- a/plugins/clay_lab/tests/tst_marklayer.qml
+++ b/plugins/clay_lab/tests/tst_marklayer.qml
@@ -1,0 +1,167 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+//
+// MarkLayer, against a stub view and a stub camera.
+//
+// Two claims are worth a suite here, and both are the kind that fail
+// invisibly. The first is the projection dependency: a screen-space overlay
+// over a 3D scene has to re-project when the camera moves, and a binding that
+// forgot to name `camera.scenePosition` looks perfect until the rig does -
+// which, in a lab whose lessons move the camera for every step, means every
+// mark sits on the wrong part. The second is the keep-out: a ring drawn where
+// the presenter is standing marks the presenter's coat, and there is no depth
+// test in screen space to stop it.
+//
+// Neither needs a GPU, a window or a real View3D: the layer only ever asks
+// its view to map one point, so a stub answers.
+
+import QtQuick
+import QtTest
+import Clayground.Lab
+
+Item {
+    id: root
+    width: 200; height: 200
+
+    // Stands in for a camera. The values are only ever read as binding
+    // dependencies, so what they hold does not matter - that they CHANGE does.
+    QtObject {
+        id: cam
+        property vector3d scenePosition: Qt.vector3d(0, 0, 0)
+        property var sceneRotation: null
+    }
+
+    // Stands in for a View3D: a projection that moves with the camera, so a
+    // mark that does not follow it can be told from one that does.
+    // It counts nothing: a stub that wrote a property of its own inside the
+    // call would be read AND written by the projection binding, and QML calls
+    // that a binding loop.
+    QtObject {
+        id: view
+        function mapFrom3DScene(p) {
+            return Qt.vector3d(p.x - cam.scenePosition.x,
+                               p.y - cam.scenePosition.y,
+                               1)          // in front of the camera
+        }
+    }
+
+    MarkLayer {
+        id: layer
+        anchors.fill: parent
+        view: view
+        camera: cam
+        pulseMs: 0            // no animation to wait on
+    }
+
+    TestCase {
+        name: "MarkLayer"
+        when: windowShown
+
+        function markItems() {
+            const out = []
+            for (let i = 0; i < layer.children.length; ++i)
+                if (layer.children[i].objectName === "mark")
+                    out.push(layer.children[i])
+            return out
+        }
+
+        function init() {
+            layer.keepOut = null
+            layer.marks = []
+            cam.scenePosition = Qt.vector3d(0, 0, 0)
+        }
+
+        function test_empty_draws_nothing() {
+            compare(layer.count, 0)
+            compare(markItems().length, 0)
+        }
+
+        function test_both_spellings_are_accepted() {
+            layer.marks = [Qt.vector3d(10, 20, 0),
+                           { at: Qt.vector3d(30, 40, 0), label: "collector" }]
+            compare(layer.count, 2)
+            const items = markItems()
+            compare(items.length, 2)
+            compare(items[0].modelData.label, "", "a bare point has no caption")
+            compare(items[1].modelData.label, "collector")
+        }
+
+        function test_entries_without_a_point_are_dropped() {
+            // What an unresolved name used to look like: a ring at the origin.
+            layer.marks = [null, {}, { at: null, label: "nowhere" },
+                           Qt.vector3d(1, 2, 0)]
+            compare(layer.count, 1)
+            compare(markItems().length, 1)
+        }
+
+        function test_marks_are_placed_where_they_project() {
+            layer.marks = [Qt.vector3d(10, 20, 0)]
+            const m = markItems()[0]
+            compare(m.x, 10)
+            compare(m.y, 20)
+            compare(layer.screenOf(0).x, 10)
+            compare(layer.screenOf(0).y, 20)
+        }
+
+        // The one this component exists to get right.
+        function test_a_mark_survives_the_camera_moving() {
+            layer.marks = [Qt.vector3d(10, 20, 0)]
+            const m = markItems()[0]
+            compare(m.x, 10)
+            cam.scenePosition = Qt.vector3d(4, 0, 0)
+            compare(m.x, 6, "the mark re-projected when the camera moved")
+            cam.scenePosition = Qt.vector3d(-6, 0, 0)
+            compare(m.x, 16)
+        }
+
+        function test_a_point_behind_the_camera_is_not_drawn() {
+            layer.marks = [Qt.vector3d(10, 20, 0)]
+            compare(markItems()[0].shown, true)
+            // The stub reports z = 1; a real view reports <= 0 behind it.
+            layer.view = null
+            compare(markItems()[0].shown, false)
+            layer.view = view
+        }
+
+        function test_keep_out_answers_for_a_point() {
+            compare(layer.clear(10, 10), true, "no box: everything is clear")
+            layer.keepOut = ({ x: 0, y: 0, width: 50, height: 50 })
+            compare(layer.clear(10, 10), false)
+            compare(layer.clear(60, 10), true)
+            compare(layer.clear(10, 60), true)
+            compare(layer.clear(50, 50), false, "the edge belongs to the box")
+        }
+
+        // Never sits on the presenter: a mark whose point lands inside the
+        // box goes to zero opacity, and comes back when it leaves.
+        function test_a_mark_on_the_presenter_fades_out() {
+            layer.keepOut = ({ x: 0, y: 0, width: 50, height: 50 })
+            layer.marks = [Qt.vector3d(10, 20, 0), Qt.vector3d(120, 120, 0)]
+            const items = markItems()
+            compare(items[0].shown, false, "inside the presenter's box")
+            compare(items[1].shown, true, "well clear of it")
+            tryCompare(items[0], "opacity", 0)
+            tryCompare(items[1], "opacity", 1)
+            // The presenter walks off: the mark comes back.
+            layer.keepOut = null
+            compare(items[0].shown, true)
+            tryCompare(items[0], "opacity", 1)
+        }
+
+        function test_replacing_the_list_replaces_the_marks() {
+            layer.marks = [Qt.vector3d(1, 1, 0), Qt.vector3d(2, 2, 0)]
+            compare(layer.count, 2)
+            layer.marks = [Qt.vector3d(3, 3, 0)]
+            compare(layer.count, 1)
+            compare(markItems().length, 1)
+            layer.marks = []
+            compare(layer.count, 0)
+            compare(markItems().length, 0)
+        }
+
+        function test_screenOf_is_bounds_checked() {
+            layer.marks = [Qt.vector3d(1, 1, 0)]
+            compare(layer.screenOf(-1).x, 0)
+            compare(layer.screenOf(7).x, 0)
+        }
+    }
+}

--- a/skills/clay-lab/SKILL.md
+++ b/skills/clay-lab/SKILL.md
@@ -228,6 +228,17 @@ Kernel (`import Clayground.Lab`):
 - **`WorldLabel`** — 2D paper chip pinned to a 3D point (meter pills,
   value tags, selection cards). Sibling of the View3D, not inside it; it
   already carries the camera-dependency fix from the pitfall list.
+- **`MarkLayer`** — rings on the parts a line is naming *while* it names
+  them, so the eye can follow the sentence instead of hunting by ear. Same
+  place as `WorldLabel`, same camera-dependency fix. Two sources, one
+  drawing: `FlowStep.mark: ["battery", "switch"]` marks for the whole step,
+  and a performance script's `*mark the battery, the switch*` marks for the
+  length of the one line that follows it. Names resolve exactly as
+  `*point at NAME*` does, so a mark can land on a sub-part (a transistor's
+  collector pad) as easily as on a part. Give it `keepOut` — the presenter's
+  projected box, the same one `BoardOverlay` takes — or a ring drawn on the
+  teacher's coat marks the coat. Captions come from `FlowGuide.markLabelOf`,
+  because the names themselves are language-neutral authoring tokens.
 - **`LabTheme`** / **`ThemeSwitch`** / **`ScaleSwitch`** — all
   colour/shape/type/spacing tokens in a light and a dark palette, plus
   `inkOn()` and `step()`; see Design language. Drop the switches beside
@@ -602,6 +613,11 @@ knowing:
   transistors frames all five. The flow's own `frame` verb should stand
   aside while the presenter is on stage (electronics-101 does), or the step
   entry cuts to a wide shot the presenter then flies out of.
+- **A step that raises marks must hold its shot.** `subjectOf`'s `hold`
+  keeps the two-shot instead of pulling in to a portrait; without it the
+  camera is on the teacher's face while the rings are on the board behind
+  the frame. electronics-101 decides it from the step itself — a task step,
+  or any step with a `mark` list.
 
 One trap, and it cost a render: `WatchChip`, `WatchMark` and `OrbitInput3D`
 all declare a property whose name matches the id a lab habitually uses


### PR DESCRIPTION
A line that names parts can now ring them while it names them: `*mark the collector, the base*` in a performance script, or `mark: ["battery", "switch"]` on a `FlowStep`, resolved through the same lookup `*point at NAME*` uses and drawn by a new kernel overlay.

- `Performance` gains the `mark` cue: it resolves every name (comma separated for a group), publishes the world points in `marks` and the names in `markNames`, and drops them when the one line that follows the cue ends — also on `stop()` and at the end of the script. Nothing is asked of the performer; a name that does not resolve is skipped and the rest of the list still marks.
- `Clayground.Lab`'s `MarkLayer` draws them: a ring per point, an optional caption chip under it, projected per frame with `camera.scenePosition`/`sceneRotation` named as dependencies so a mark survives the camera moving, and a `keepOut` rectangle — the presenter's projected box, the same one `BoardOverlay` takes — that fades a ring landing on the teacher instead of drawing it on his coat.
- `FlowStep.mark` and the readonly `Flow.marks` are the flow-step half; the professor kit's `FlowGuide` takes `marks:` and `markLabelOf:` and publishes resolved `markPoints`. A step with a performance script ignores its `mark` field — that step's marks come from its own cues, per line.
- electronics-101 names its parts and its sub-parts: `scriptTarget` answers `collector`/`base`/`emitter` from the transistor's pads and the bare type names alongside the existing prose ones, `markLabel` captions a ring in the reader's language, and the `meet` and `wire` steps carry `mark:` lists.
- A step that raises marks now holds its two-shot. Without it the `wire` step ended in a portrait of the professor with the whole ringed loop off-frame.

Verified:
- `ctest --preset default` → exit 0, 51/51 passed (includes `lab_check_electronics-101`, `qml_lab_qml`, `qml_character3d_qml`)
- `node plugins/clay_character3d/scripting/performancescript.test.js` → exit 0, 139 passed, 0 failed (14 new, covering the cue, the comma list and the cross-language lint)
- `qml_lab_qml` → 151 passed, 0 failed; the 11 new `MarkLayer` cases include "a mark survives the camera moving" and "a mark on the presenter fades out"
- `qml_character3d_qml` → 32 passed, 0 failed; the 11 new `PerformanceMarks` cases pin the lifetime rule
- criterion 3, EN: `clayrender … --eval 'root.startFlow("logic-gates")'` → exit 0, marks `["collector","base","emitter"]` at the transistor's three pads; the `wire` step → `["Battery","Switch","LED","Resistor"]`
- criterion 3, DE: the same two runs with `LabLang.lang = "de"` → `["Kollektor","Basis","Emitter"]` and `["Batterie","Schalter","LED","Widerstand"]`
- criterion 2, in the lab: at the `meet` step `markLayer.keepOut` tracks the professor (`x 663…803, y 339…521` at 1400x900), a point inside it is not drawn, and none of the three marks fall in it
- `15 files changed, 962 insertions(+), 11 deletions(-)`

Not verified: Windows and Linux — both new QML suites run under the `IMPORTS_BUILT_MODULE`/relative-import test hosts, and the built-module ones are disabled on Windows (#192). The ring, halo and chip were judged from two screenshots, not measured.

<details><summary>The parked decision, the two screenshots, and the first-build test failure</summary>

**Parked on the issue** ([comment](https://github.com/MisterGC/clayground/issues/222#issuecomment-5551756093)): the marks made an existing mismatch visible. The `meet` line says "collector on the left, emitter on the right, base facing you", but the `transistor` preset places the part with `addRotated(..., 3)`, so in the two-shot the step holds the legs land at screen x — base 409, emitter 464, collector 503. The rings are on the real pads; the words are what do not match. Not new, just no longer unfalsifiable. Three ways out are on the issue; none taken here.

**What the two steps look like.** `meet`: three rings on the transistor's legs, captioned `collector` / `base` / `emitter`, the professor standing clear to the right. `wire`: the whole four-part loop ringed and captioned in German (`Batterie`, `Schalter`, `LED`, `Widerstand`), the professor behind it. Both taken with `clayrender --size 1400x900 --settle`.

**Design notes.**
- The lifetime lives in the sequencer, not in the drawing: `Performance` knows when a line ends, an overlay does not. `_markState` is `""` / `"armed"` / `"showing"`, and the clear happens at the top of the cue after the line.
- Mark names are language-neutral authoring tokens on purpose — that is what lets `lint()` compare an EN and a DE script — so the caption comes from the lab through `markLabelOf` instead.
- `MarkLayer.marks` accepts a bare `vector3d` or `{at, label}`; entries without a usable point are dropped rather than drawn at the origin, which is what an unresolved name used to look like.
- The delegate carries `objectName: "mark"` so a headless render can pick the marks out without counting anonymous children.
- Not added: an `*unmark*` directive. The one-line rule needs no explicit clear, and a verb with no use is a verb to keep working.

**A failure that was not this branch.** The first `ctest --preset default` in this fresh worktree reported 50/51 with `testsbx_plugin` failing — `module "Clayground.MyPlugin" plugin "MyPluginplugin" not found`, the known first-parallel-build copy order (#188 family). `rm build/bin/sbx_plugin.app/Contents/MacOS/sbx_plugin && cmake --build build --target sbx_plugin` then passed it, and the full rerun quoted above is 51/51.

</details>

Closes #222
