### PR TITLE
character3d: a two-segment torso - belly and chest on a waist joint

### DIFF
--- a/plugins/clay_character3d/CMakeLists.txt
+++ b/plugins/clay_character3d/CMakeLists.txt
@@ -108,6 +108,8 @@ clay_add_qml_test(character3d_qml DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/qm
 
 # The head itself needs Canvas3D's C++ Box3DGeometry, so this half loads the
 # built module and is the half Windows has to skip.
+# tst_headpose.qml and tst_torso.qml both live here: a Head and a Character
+# are made of Box3D, whose geometry is C++ in Canvas3D.
 clay_add_qml_test(character3d_head_qml IMPORTS_BUILT_MODULE
                   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/qml_head)
 

--- a/plugins/clay_character3d/Character.qml
+++ b/plugins/clay_character3d/Character.qml
@@ -132,7 +132,7 @@ BodyPartsGroup {
 
         The thing to assert on: it says what the character was asked to do,
         where a joint angle mid-swing says only where the leg happens to be.
-        Keys are the eleven factors of \l Gait.
+        Keys are the twelve factors of \l Gait.
     */
     readonly property var gaitFactors: GaitLib.compose([
         _character.gaitFromBuild ? GaitLib.buildFactors(_character.gaitBuild) : null,
@@ -162,8 +162,8 @@ BodyPartsGroup {
 
         Pure: the same answer as the running cycle would give at that moment,
         computed from \l gaitFactors. Returns \c {{rightLeg, leftLeg, rightArm,
-        leftArm, hip, torso, head, lift}} in the joints' own conventions, lift
-        in leg heights. The cycle sheet is drawn from it.
+        leftArm, hip, torso, belly, chest, head, lift}} in the joints' own
+        conventions, lift in leg heights. The cycle sheet is drawn from it.
     */
     function gaitPoseAt(base, t) {
         return GaitLib.poseAt(GaitLib.derive(base, _character.gaitFactors), t)
@@ -198,14 +198,17 @@ BodyPartsGroup {
         arm(_leftArm, p.leftArm)
         _hip.eulerRotation = Qt.vector3d(p.hip[0], p.hip[1], p.hip[2])
         _torso.eulerRotation = Qt.vector3d(p.torso[0], p.torso[1], p.torso[2])
+        _belly.eulerRotation = Qt.vector3d(p.belly[0], p.belly[1], p.belly[2])
+        _chest.eulerRotation = Qt.vector3d(p.chest[0], p.chest[1], p.chest[2])
         _head.poseEuler = Qt.vector3d(p.head[0], p.head[1], p.head[2])
         _character._heldLift = p.lift * _character.legHeight
     }
 
     // Bounding box dimensions (derived from body parts)
-    width: Math.max(shoulderWidth, waistWidth, hipWidth)
+    width: Math.max(shoulderWidth, waistWidth, hipWidth, _belly.width,
+                    _character._waistJointWidth)
     height: footHeight + legHeight + hipHeight + torsoHeight + neckHeight + headHeight
-    depth: Math.max(torsoDepth, hipDepth)
+    depth: Math.max(torsoDepth, hipDepth, _belly.depth, _chest.depth)
 
     // ============================================================================
     // ACTIVITY & BEHAVIOR PROPERTIES
@@ -1028,11 +1031,94 @@ BodyPartsGroup {
     property alias torsoHeight: _torso.height
     /*! Depth of the torso. */
     property alias torsoDepth: _torso.depth
-    /*! Width at the waist. */
+    /*! Width at the waist - where the trunk meets the hip. */
     property alias waistWidth: _torso.waistWidth
 
-    /*! Torso/shirt color. */
-    property alias torsoColor: _torso.color
+    /*!
+        \qmlproperty real Character::bellyRatio
+        \brief The belly's share of \l torsoHeight, 0..1. The rest is the
+               chest, and the waist joint sits between them.
+
+        The trunk is two boxes on a joint rather than one box, which is what
+        lets a back round and a chest swell. 0.45 puts the joint where a waist
+        is; at that value, and with \l bellyBulge, \l chestSwell and
+        \l waistPinch left alone, the pair traces exactly the tapered box the
+        torso used to be.
+
+        \sa belly, chest, Gait::spineCurve
+    */
+    property real bellyRatio: 0.45
+
+    /*!
+        \qmlproperty real Character::bellyBulge
+        \brief How far the belly swells past the plain trunk taper. 1 leaves
+               it alone, 1.3 is a gut, below 1 tucks it in.
+
+        Mostly depth and rather less width, because that is how a belly reads:
+        it grows forward. The bottom of the belly stays at \l waistWidth by
+        \l torsoDepth however far it bulges, so the swell hangs off the ribs
+        rather than off the pelvis. \l ParametricCharacter drives it from
+        \c mass.
+    */
+    property real bellyBulge: 1.0
+
+    /*!
+        \qmlproperty real Character::chestSwell
+        \brief How much deeper the chest is than the plain trunk taper. 1
+               leaves it alone.
+
+        Depth only: the chest's width is \l shoulderWidth and stays it.
+        \l ParametricCharacter drives it from \c muscle.
+    */
+    property real chestSwell: 1.0
+
+    /*!
+        \qmlproperty real Character::waistPinch
+        \brief How far in the waist joint is drawn, as a fraction of the
+               width the taper would have there. 0 (the default) is no pinch.
+
+        The one shape a single tapered box could not make: narrow in the
+        middle and wider at both ends.
+    */
+    property real waistPinch: 0.0
+
+    /*! Torso/shirt color - both segments unless one is given its own. */
+    property color torsoColor: "red"
+
+    /*!
+        \qmlproperty color Character::bellyColor
+        \brief Colour of the lower trunk. Follows \l torsoColor until set.
+    */
+    property color bellyColor: _character.torsoColor
+
+    /*!
+        \qmlproperty color Character::chestColor
+        \brief Colour of the upper trunk. Follows \l torsoColor until set.
+    */
+    property color chestColor: _character.torsoColor
+
+    // The geometry the two segments are cut from. Clamped here rather than at
+    // every use: a bellyRatio of 0 or 1 is a box of zero height, and a
+    // faceScale divides by these.
+    readonly property real _bellyRatioC: Math.max(0.05, Math.min(0.95, _character.bellyRatio))
+    readonly property real _bellyBulgeC: Math.max(0.2, _character.bellyBulge)
+    readonly property real _chestSwellC: Math.max(0.2, _character.chestSwell)
+    // Where the old single box was, at the height the joint cuts it, less
+    // whatever the waist is pinched by.
+    readonly property real _waistJointWidth:
+        (_character.waistWidth
+         + (_character.shoulderWidth - _character.waistWidth) * _character._bellyRatioC)
+        * (1 - Math.max(0, Math.min(0.6, _character.waistPinch)))
+    // A belly is mostly depth: a third of the bulge goes into the width and
+    // the rest forward. Width is the expensive axis - a ParametricCharacter
+    // already widens the whole body with mass, and adding much more here is
+    // how a heavy, muscular build turns into a slab wider than it is tall.
+    readonly property real _bellyWidthK: 1 + (_character._bellyBulgeC - 1) * 0.35
+    // How far forward the belly box is pushed, so a gut is in front of the
+    // body rather than around it. A third of the extra depth; the chest and
+    // the hip take it straight back out.
+    readonly property real _bellyForward:
+        _character.torsoDepth * (_character._bellyBulgeC - 1) * 0.33
 
     // ============================================================================
     // HIP PROPERTIES
@@ -1144,10 +1230,39 @@ BodyPartsGroup {
     readonly property Leg rightLeg: _rightLeg
     /*! Reference to the head for animation. */
     readonly property Head head: _head
-    /*! Reference to the torso. */
+    /*!
+        \qmlproperty BodyPart Character::torso
+        \readonly
+        \brief The trunk as a whole - the frame \l belly and \l chest hang
+               in. It draws nothing; turning it turns the whole upper body,
+               which is what sway and rock do.
+    */
     readonly property BodyPart torso: _torso
+    /*!
+        \qmlproperty BodyPart Character::belly
+        \readonly
+        \brief The lower trunk. Pitching it bends the body at the hip; the
+               chest, the arms and the head come with it.
+    */
+    readonly property BodyPart belly: _belly
+    /*!
+        \qmlproperty BodyPart Character::chest
+        \readonly
+        \brief The upper trunk, on the waist joint. Pitching it against the
+               belly is what rounds a back or lifts a chest - a curve rather
+               than a tilt.
+    */
+    readonly property BodyPart chest: _chest
     /*! Reference to the hip. */
     readonly property BodyPart hip: _hip
+
+    // Where the chest node sits in the character's own frame. The belly's
+    // forward offset and the chest's counter-offset cancel, so this is the
+    // waist joint on the trunk's own axis however far the belly bulges.
+    readonly property vector3d _chestOrigin: Qt.vector3d(
+        _torso.basePos.x + _belly.basePos.x + _chest.basePos.x,
+        _torso.basePos.y + _belly.basePos.y + _chest.basePos.y,
+        _torso.basePos.z + _belly.basePos.z + _chest.basePos.z)
 
     /*!
         \qmlproperty vector3d Character::rightShoulderPos
@@ -1161,9 +1276,9 @@ BodyPartsGroup {
         keeps pointing at a shoulder when the torso's proportions change.
     */
     readonly property vector3d rightShoulderPos: Qt.vector3d(
-        _torso.basePos.x + _rightArm.basePos.x,
-        _torso.basePos.y + _rightArm.basePos.y,
-        _torso.basePos.z + _rightArm.basePos.z)
+        _character._chestOrigin.x + _rightArm.basePos.x,
+        _character._chestOrigin.y + _rightArm.basePos.y,
+        _character._chestOrigin.z + _rightArm.basePos.z)
 
     /*!
         \qmlproperty vector3d Character::leftShoulderPos
@@ -1172,9 +1287,9 @@ BodyPartsGroup {
                coordinates.
     */
     readonly property vector3d leftShoulderPos: Qt.vector3d(
-        _torso.basePos.x + _leftArm.basePos.x,
-        _torso.basePos.y + _leftArm.basePos.y,
-        _torso.basePos.z + _leftArm.basePos.z)
+        _character._chestOrigin.x + _leftArm.basePos.x,
+        _character._chestOrigin.y + _leftArm.basePos.y,
+        _character._chestOrigin.z + _leftArm.basePos.z)
 
     /*!
         \qmlproperty vector3d Character::headPos
@@ -1183,11 +1298,19 @@ BodyPartsGroup {
                the origin of the anchors published by \l Head.
     */
     readonly property vector3d headPos: Qt.vector3d(
-        _torso.basePos.x + _head.basePos.x,
-        _torso.basePos.y + _head.basePos.y,
-        _torso.basePos.z + _head.basePos.z)
+        _character._chestOrigin.x + _head.basePos.x,
+        _character._chestOrigin.y + _head.basePos.y,
+        _character._chestOrigin.z + _head.basePos.z)
 
-    BodyPart {
+    // The trunk. The node itself draws nothing: it is the frame the two
+    // segments hang in, and it keeps every dimension the single-box torso had
+    // - width is the shoulders, height the whole torso, depth the trunk - so
+    // shoulderWidth, torsoHeight, torsoDepth and waistWidth still name what
+    // they always named. What changed is what is inside it: a belly and a
+    // chest on a waist joint, so the trunk can round and swell instead of
+    // only tipping. At the default bellyRatio, bellyBulge, chestSwell and
+    // waistPinch the pair traces exactly the trapezoid the one box drew.
+    BodyPartsGroup {
         id: _torso
 
         width: 3.5
@@ -1195,17 +1318,62 @@ BodyPartsGroup {
         depth: 1.25
         property real waistWidth: 3.0
 
-        scaledFace: Box3DGeometry.BottomFace
-        faceScale: Qt.vector2d(waistWidth/width, 1.0)
         // Position torso above legs, feet, and hip - plus whatever the gait
         // is lifting the whole figure by this instant. Everything hangs off
         // the torso, so this is the figure's bounce, feet included.
         basePos: Qt.vector3d(0, _character.legHeight + _character.footHeight + _hip.height
                                 + _character.gaitLift, 0)
 
+      BodyPart {
+        id: _belly
+
+        // The box is measured at its BOTTOM, where it meets the hip, and its
+        // top face is scaled to the width the old trapezoid had at the waist
+        // joint. That way round on purpose: a belly is widest low and hangs
+        // OVER the belt, so the bulge has to grow the end that sits on the
+        // hip. Scaled the other way it grew under the ribs and tapered into
+        // the pelvis, which reads as a barrel rather than as a gut.
+        //
+        // At bellyBulge 1 the bottom is exactly waistWidth by torsoDepth and
+        // the top exactly the joint section, so the pair still traces the
+        // single box's outline.
+        width: _character.waistWidth * _character._bellyWidthK
+        height: _character.torsoHeight * _character._bellyRatioC
+        depth: _character.torsoDepth * _character._bellyBulgeC
+        color: _character.bellyColor
+
+        scaledFace: Box3DGeometry.TopFace
+        faceScale: Qt.vector2d(_character._waistJointWidth / Math.max(1e-6, _belly.width),
+                               _character.torsoDepth / Math.max(1e-6, _belly.depth))
+
+        // A belly grows forward more than back. Only the box moves; the chest
+        // and the hip take the offset straight back out (see their basePos)
+        // so the head, the shoulders and the legs all stay on the trunk's own
+        // axis however far it bulges.
+        basePos: Qt.vector3d(0, 0, _character._bellyForward)
+
+      BodyPart {
+        id: _chest
+
+        // Sits on the waist joint. The z undoes the belly's forward offset.
+        basePos: Qt.vector3d(0, _belly.height, -_character._bellyForward)
+
+        width: _character.shoulderWidth
+        height: _character.torsoHeight * (1 - _character._bellyRatioC)
+        depth: _character.torsoDepth * _character._chestSwellC
+        color: _character.chestColor
+
+        // The bottom face is the belly's TOP face - the joint section, which
+        // is the same whatever the belly is doing below it. A bulged belly
+        // therefore steps out from under the chest rather than dragging the
+        // ribcage wider with it.
+        scaledFace: Box3DGeometry.BottomFace
+        faceScale: Qt.vector2d(_character._waistJointWidth / Math.max(1e-6, _chest.width),
+                               _character.torsoDepth / Math.max(1e-6, _chest.depth))
+
         Head {
             id: _head
-            basePos:  Qt.vector3d(0, (_torso.height + _character.neckHeight), 0)
+            basePos:  Qt.vector3d(0, (_chest.height + _character.neckHeight), 0)
             speechSource: _speech
 
             // The face is no longer something a distant character stops paying
@@ -1241,7 +1409,7 @@ BodyPartsGroup {
         // keeps whatever the character was asked to hold.
         Arm {
             id: _rightArm
-            basePos: Qt.vector3d(_character.shoulderWidth * 0.5, _torso.height, 0)
+            basePos: Qt.vector3d(_character.shoulderWidth * 0.5, _chest.height, 0)
 
             articulated: _character.detailedHands
             handPose: _gestureAnim.rightHandPose !== "" ? _gestureAnim.rightHandPose
@@ -1250,7 +1418,7 @@ BodyPartsGroup {
 
         Arm {
             id: _leftArm
-            basePos: Qt.vector3d(-_character.shoulderWidth * 0.5, _torso.height, 0)
+            basePos: Qt.vector3d(-_character.shoulderWidth * 0.5, _chest.height, 0)
 
             mirrored: true
             articulated: _character.detailedHands
@@ -1279,7 +1447,12 @@ BodyPartsGroup {
             handDepth: _rightArm.handDepth
         }
 
-        // Hip (containing legs)
+      }   // _chest
+
+        // Hip (containing legs). It hangs off the BELLY, not off the trunk
+        // group: the pelvis follows the lower back, so a hip that counters
+        // the trunk's tilt only has the belly's share of it to counter. See
+        // hipLean in gait.js.
         BodyPart {
             id: _hip
             width: 3.0
@@ -1289,7 +1462,9 @@ BodyPartsGroup {
 
             scaledFace: Box3DGeometry.TopFace
             faceScale: Qt.vector2d(_torso.waistWidth/width, 1.0)
-            basePos: Qt.vector3d(0, -_hip.height, 0)
+            // The z undoes the belly's forward offset, the same way the
+            // chest's does: a gut moves the box, not the skeleton.
+            basePos: Qt.vector3d(0, -_hip.height, -_character._bellyForward)
 
             // Legs (containing feet)
             // Hip joint aligns with hip bottom (legs extend downward from there)
@@ -1320,7 +1495,9 @@ BodyPartsGroup {
                 footDepth: _rightLeg.footDepth
             }
         }
-    }
+
+      }   // _belly
+    }   // _torso
 
     // The two gaits. Angles and cycle length come from gaitFactors through
     // gait.js; the entity's legHeight sets the stride and so the speed.

--- a/plugins/clay_character3d/Character.qml
+++ b/plugins/clay_character3d/Character.qml
@@ -132,7 +132,7 @@ BodyPartsGroup {
 
         The thing to assert on: it says what the character was asked to do,
         where a joint angle mid-swing says only where the leg happens to be.
-        Keys are the twelve factors of \l Gait.
+        Keys are the thirteen factors of \l Gait.
     */
     readonly property var gaitFactors: GaitLib.compose([
         _character.gaitFromBuild ? GaitLib.buildFactors(_character.gaitBuild) : null,
@@ -188,7 +188,7 @@ BodyPartsGroup {
             l.foot.eulerRotation = Qt.vector3d(a.foot, 0, 0)
         }
         function arm(m, a) {
-            m.upperArm.eulerRotation = Qt.vector3d(a.upper, 0, 0)
+            m.upperArm.eulerRotation = Qt.vector3d(a.upper, 0, a.out)
             m.lowerArm.eulerRotation = Qt.vector3d(a.lower, 0, 0)
             m.hand.eulerRotation = Qt.vector3d(0, 0, 0)
         }

--- a/plugins/clay_character3d/Gait.qml
+++ b/plugins/clay_character3d/Gait.qml
@@ -6,7 +6,7 @@ import "animation/gait.js" as GaitLib
     \qmltype Gait
     \inqmlmodule Clayground.Character3D
     \inherits QtObject
-    \brief How a character walks and runs: a named preset, eleven factors, or both.
+    \brief How a character walks and runs: a named preset, twelve factors, or both.
 
     Every factor is 1 (the multiplicative ones) or 0 (the additive ones) at
     neutral, and a neutral Gait is the walk and run the framework always had.
@@ -77,8 +77,24 @@ QtObject {
         \brief Torso pitch in degrees on top of the cycle's own. Positive
                leans forward (a slump, a charge), negative back (chest out).
                Bends at the waist: the hip counters it, so the legs stay
-               planted and only chest, head and arms tip. */
+               planted and only belly, chest, head and arms tip. It is shared
+               between the two trunk segments and brings a little curve with
+               it; \l spineCurve asks for more. */
     property real lean: 0
+
+    /*!
+        \qmlproperty real Gait::spineCurve
+        \brief How round the back is, in degrees: the angle between belly and
+               chest at the waist joint. Positive rounds it forward (sad,
+               elderly, sneaking), negative arches it and lifts the chest
+               (proud, marching).
+
+        Differential, not a tilt: it bends the belly back by as much as it
+        bends the chest forward, so it changes the SHAPE of the trunk without
+        moving where the head ends up. That is \l lean's job, and the two are
+        meant to be used together - a slump is both.
+    */
+    property real spineCurve: 0
 
     /*! \qmlproperty real Gait::headPitch
         \brief Head pitch in degrees. Positive looks down, negative lifts
@@ -126,7 +142,8 @@ QtObject {
         GaitLib.presetFactors(_gait.preset),
         {
             tempo: _gait.tempo, stride: _gait.stride, bounce: _gait.bounce,
-            lean: _gait.lean, headPitch: _gait.headPitch, armSwing: _gait.armSwing,
+            lean: _gait.lean, spineCurve: _gait.spineCurve,
+            headPitch: _gait.headPitch, armSwing: _gait.armSwing,
             armForward: _gait.armForward,
             elbow: _gait.elbow, kneeLift: _gait.kneeLift, sway: _gait.sway,
             rock: _gait.rock

--- a/plugins/clay_character3d/Gait.qml
+++ b/plugins/clay_character3d/Gait.qml
@@ -6,7 +6,7 @@ import "animation/gait.js" as GaitLib
     \qmltype Gait
     \inqmlmodule Clayground.Character3D
     \inherits QtObject
-    \brief How a character walks and runs: a named preset, twelve factors, or both.
+    \brief How a character walks and runs: a named preset, thirteen factors, or both.
 
     Every factor is 1 (the multiplicative ones) or 0 (the additive ones) at
     neutral, and a neutral Gait is the walk and run the framework always had.
@@ -111,6 +111,18 @@ QtObject {
                elbows plus this is fists pumping before the chest. */
     property real armForward: 0
 
+    /*!
+        \qmlproperty real Gait::armOut
+        \brief How far the upper arms are carried out from the ribs, in
+               degrees. 0 hangs them against the body.
+
+        Held through the cycle rather than alternating with it - a carriage,
+        not a movement - and signed by the side, so both arms go outward. It
+        is what separates a walk with somewhere to be from one ready to hit
+        something, and it only reads head-on: a profile cannot see it.
+    */
+    property real armOut: 0
+
     /*! \qmlproperty real Gait::elbow
         \brief Elbow bend in degrees on top of the cycle's own (a walk bends
                10, a run 70). Bent elbows with a quick tempo read as fists
@@ -144,7 +156,7 @@ QtObject {
             tempo: _gait.tempo, stride: _gait.stride, bounce: _gait.bounce,
             lean: _gait.lean, spineCurve: _gait.spineCurve,
             headPitch: _gait.headPitch, armSwing: _gait.armSwing,
-            armForward: _gait.armForward,
+            armForward: _gait.armForward, armOut: _gait.armOut,
             elbow: _gait.elbow, kneeLift: _gait.kneeLift, sway: _gait.sway,
             rock: _gait.rock
         }

--- a/plugins/clay_character3d/ParametricCharacter.qml
+++ b/plugins/clay_character3d/ParametricCharacter.qml
@@ -233,6 +233,23 @@ Character {
     torsoDepth: _headSize * 0.7 * _widthMultiplier
     waistWidth: shoulderWidth * _waistRatio
 
+    // The two trunk segments. Where the sliders used to reach the body only
+    // as one width multiplier - a heavy character was a wider character, from
+    // the shoulders to the shins - mass now shows as a belly and muscle as a
+    // chest, which is where they show on a person. Every one of these is
+    // exactly neutral at 0.5, so a default ParametricCharacter is the tapered
+    // box it always was.
+    bellyBulge: mass >= 0.5 ? lerp(1.0, 1.45, (mass - 0.5) * 2)
+                            : lerp(1.0, 0.90, (0.5 - mass) * 2)
+    chestSwell: muscle >= 0.5 ? lerp(1.0, 1.22, (muscle - 0.5) * 2)
+                              : lerp(1.0, 0.93, (0.5 - muscle) * 2)
+    // A waist is what a build has when it is not carrying weight in front of
+    // it: the pinch comes from muscle and femininity and is given back by
+    // mass. The single tapered box could not make this shape at all.
+    waistPinch: Math.max(0, lerp(0, 0.10, Math.max(0, (muscle - 0.5) * 2))
+                          + lerp(0, 0.07, Math.max(0, (femininity - 0.5) * 2))
+                          - lerp(0, 0.14, Math.max(0, (mass - 0.5) * 2)))
+
     // Hip dimensions
     hipWidth: _headSize * 1.6 * (1.0 / _shoulderHipRatio) * _widthMultiplier
     hipHeight: _headSize * 0.6

--- a/plugins/clay_character3d/README.md
+++ b/plugins/clay_character3d/README.md
@@ -81,6 +81,28 @@ ParametricCharacter {
 }
 ```
 
+`mass` and `muscle` reach the body as a belly and a chest, not only as a
+width. The trunk is two boxes on a waist joint (see
+[The trunk is two segments](#the-trunk-is-two-segments)), so `mass` bulges the
+belly forward over the hip and `muscle` deepens the chest, and a build shows
+in the shape of the body rather than in how wide all of it is. Both are
+exactly neutral at 0.5, and `muscle` also draws a waist in that a single
+tapered box could not make.
+
+The same three dials are on `Character` directly for a body built by hand:
+
+| property | default | what it does |
+|---|---|---|
+| `bellyRatio` | 0.45 | the belly's share of `torsoHeight`; the waist joint sits between the two segments |
+| `bellyBulge` | 1 | how far the belly swells past the plain trunk taper - mostly depth, and forward. 1.3 is a gut |
+| `chestSwell` | 1 | how much deeper the chest is. Depth only: the chest's width is `shoulderWidth` |
+| `waistPinch` | 0 | how far in the waist joint is drawn |
+| `bellyColor`, `chestColor` | `torsoColor` | either segment can take its own colour |
+
+At every default the two boxes trace exactly the tapered box the torso used to
+be: same shoulders, same waist, same depth, same height. The only thing that
+is drawn and was not is the seam at the joint.
+
 ### Character with Movement
 
 ```qml
@@ -547,7 +569,7 @@ character-local coordinates for the same reason.
 
 Walk and run are one cycle, `GaitCycleAnim`, animated from a table that
 `animation/gait.js` derives from a base - the walk or the run as it was
-authored - and eleven factors around neutral. A factor that scales an amplitude
+authored - and twelve factors around neutral. A factor that scales an amplitude
 is 1 at neutral, one that offsets is 0, and the all-neutral gait is the walk
 and run the framework always had, to the digit: `gait.test.js` asserts the
 derived table against the formulas `WalkAnim` and `RunAnim` used to carry, so
@@ -597,14 +619,40 @@ The factors, as `Gait` exposes them:
 | `tempo` | multiplies | 1 | cadence; 1.2 takes steps a fifth quicker and covers ground a fifth faster |
 | `stride` | multiplies | 1 | how far the legs swing, and the speed with it |
 | `bounce` | adds | 0 | how high the whole figure rises at mid-step, in leg heights; 0.1 is the cap |
-| `lean` | adds | 0 | torso pitch in degrees on top of the cycle's own, bending at the waist so the legs stay planted; positive forward, negative chest out |
+| `lean` | adds | 0 | trunk pitch in degrees on top of the cycle's own, bending at the waist so the legs stay planted; positive forward, negative chest out |
+| `spineCurve` | adds | 0 | how round the back is: the angle between belly and chest. Differential, so it changes the shape of the trunk without moving the head - positive rounds it forward, negative arches it and lifts the chest |
 | `headPitch` | adds | 0 | head pitch in degrees; positive looks down, negative lifts the chin |
 | `armSwing` | multiplies | 1 | arm swing amplitude; 0 hangs the arms |
 | `armForward` | adds | 0 | degrees the whole swing is carried ahead of the body, same amplitude; bent elbows plus this is fists pumping before the chest |
 | `elbow` | adds | 0 | elbow bend in degrees on top of the cycle's own (a walk bends 10, a run 70) |
 | `kneeLift` | multiplies | 1 | knee lift; below 1 drags the feet, above it high-steps; the foot angles follow |
-| `sway` | adds | 0 | hip yaw in degrees, alternating with the step, the torso countering by half |
-| `rock` | adds | 0 | torso roll in degrees over the planted leg, alternating with the step |
+| `sway` | adds | 0 | hip yaw in degrees, alternating with the step, the shoulders countering by half |
+| `rock` | adds | 0 | trunk roll in degrees over the planted leg, alternating with the step |
+
+#### The trunk is two segments
+
+`Character.torso` is a group that draws nothing. What draws is `belly` and
+`chest`, two boxes on a waist joint, and that is where a trunk pitch lives -
+the group carries only the sway and the rock. The two pitches always add up to
+`lean`, so the head and the shoulders end up exactly where a single-box torso
+put them; their DIFFERENCE is `spineCurve`, and it is the difference that
+reads. A `lean` on its own tips the figure like a plank; a `lean` with a curve
+settles the belly back and rounds the chest forward over it, which is what
+makes a slump look like weight and a proud walk like air in the chest.
+
+A factor `lean` brings a little curve with it on its own, because a body that
+is asked to lean bends. A BASE lean does not: a run's authored 12 degrees is a
+sprinter's straight line from the ankles, so it goes on the belly whole and
+the waist joint stays shut.
+
+The hip hangs off the belly and gives the belly's share of the bend straight
+back, so the legs stay where the base asked for them - upright under a factor
+lean, tipped with the whole figure under a run's. `gaitPoseAt()` reports all
+four: `hip`, `torso`, `belly`, `chest`.
+
+The same split is what `TalkGestureAnim`, `GestureAnim`'s talking beats and
+`UseAnim` bend with, so a character that leans while it speaks and a character
+that leans while it walks bend the same way.
 
 Presets, by name (`Gait.presetNames`): `neutral` changes nothing; `cheerful`,
 `dejected` and `furious` are exactly what the `happy`, `sad` and `angry`
@@ -612,10 +660,18 @@ emotions do to a walk - they share their rows in `gait.js`, so
 `setEmotion("sad")` and `preset: "dejected"` cannot drift apart; `elderly` is
 the top of the maturity slider (slow, short, shuffling, stooped) and `toddler`
 its bottom with a touch more tempo; `heavy` is the top of the mass slider with
-more rock; `sneak` is slow and short with high knees, leaning in, head down,
-elbows bent and the arms held still; `proud` is chest out, chin up and arms
+more rock, leaning BACK over the weight it is carrying; `sneak` is slow and
+short with high knees, a rounded back, head down, elbows bent and the arms
+held still; `proud` is an arched back and a lifted chest, chin up and arms
 swinging over a slightly longer, slower step; `march` is high knees, a wide
-arm swing and straight elbows. A name that is not in the list does nothing
+arm swing, straight elbows and a straight back.
+
+`furious` is short, hard, quick steps with the knees stamping, the shoulders
+hunched over a forward head and the fists carried before the chest by a bent
+elbow - not a bigger walk. Two earlier versions of it were: one slid the whole
+arm swing 22 degrees forward, the other folded the elbow to 80, and both put
+the forearms out in front where they barely alternated, which reads as a
+sleepwalker from every angle. The cycle sheet is what settled it. A name that is not in the list does nothing
 and clears `Gait.presetKnown`.
 
 How the build maps (`buildFactors()` in `gait.js`): every default is exactly
@@ -624,9 +680,10 @@ neutral, and each effect fades in linearly toward the end of its slider.
 bounce), above 0.75 the elderly zone, and neutral in between - the proportion
 tables treat 1 as a full adult, so only the top quarter reads as elderly, for
 gait alone. `femininity`, `mass` and `muscle` fade out toward 0.5: feminine
-sways and swings the arms less, masculine rocks a little; heavy is slower and
-rocks more, light a touch quicker; athletic leans in and swings the arms, soft
-slumps. `bodyHeight` and `realism` do not enter the gait (the leg height they
+sways and swings the arms less, masculine rocks a little; heavy is slower,
+rocks more and leans back over its weight, light a touch quicker; athletic
+leans in with the chest up and swings the arms, soft slumps and rounds its
+back. `bodyHeight` and `realism` do not enter the gait (the leg height they
 set enters the speed). The effects are kept subtle so the sliders stay a body
 and not a costume: `gait.test.js` checks that no corner of the four sliders
 leaves a walk.
@@ -646,6 +703,12 @@ clayrender plugins/clay_character3d/bench/GaitSheetSandbox.qml --size 1800x500 \
     --set 'preset="elderly"' --set 'emotion="sad"' --set 'maturity=0.9' \
     --set 'frames=8' --set 'yaw=90' --wait-for 'ready' --out /tmp/elderly.png
 ```
+
+`yaw` turns the figures - 90 side-on, 0 head-on, 180 from behind - and `pitch`
+lifts the camera instead, 90 being straight down. Check a change against all
+four: a silhouette that reads as walking from the side and from nowhere else
+is a side view, and the overhead is the only one that shows sway and shoulder
+counter-rotation honestly.
 
 To assert on a gait, read `gaitFactors`: it says what the character was asked
 to do, where a joint angle mid-swing says only where the leg happens to be.
@@ -668,7 +731,7 @@ running, and `applyGaitPose(base, t)` freezes an idle character there.
 
 The Character3D plugin implements:
 
-- **Modular Body Parts**: Head, torso, arms, legs with independent dimensions
+- **Modular Body Parts**: Head, a two-segment trunk on a waist joint, arms, legs, all with independent dimensions
 - **Procedural Animation**: Idle derived from body geometry; walk and run are one `GaitCycleAnim` over a table that `gait.js` derives from a base (the authored walk or run) plus the composed gait factors
 - **Animation-Speed Coupling**: Movement speeds calculated from the derived table's leg swing angles and the leg height, so speed still follows the feet whatever the gait
 - **Facial Expressions**: Multiple expression states (idle, joy, anger, sadness, talk)

--- a/plugins/clay_character3d/README.md
+++ b/plugins/clay_character3d/README.md
@@ -569,7 +569,7 @@ character-local coordinates for the same reason.
 
 Walk and run are one cycle, `GaitCycleAnim`, animated from a table that
 `animation/gait.js` derives from a base - the walk or the run as it was
-authored - and twelve factors around neutral. A factor that scales an amplitude
+authored - and thirteen factors around neutral. A factor that scales an amplitude
 is 1 at neutral, one that offsets is 0, and the all-neutral gait is the walk
 and run the framework always had, to the digit: `gait.test.js` asserts the
 derived table against the formulas `WalkAnim` and `RunAnim` used to carry, so
@@ -624,6 +624,7 @@ The factors, as `Gait` exposes them:
 | `headPitch` | adds | 0 | head pitch in degrees; positive looks down, negative lifts the chin |
 | `armSwing` | multiplies | 1 | arm swing amplitude; 0 hangs the arms |
 | `armForward` | adds | 0 | degrees the whole swing is carried ahead of the body, same amplitude; bent elbows plus this is fists pumping before the chest |
+| `armOut` | adds | 0 | degrees the upper arms are carried out from the ribs, held through the cycle rather than alternating. Only reads head-on, and it is what separates a walk with somewhere to be from one ready to hit something |
 | `elbow` | adds | 0 | elbow bend in degrees on top of the cycle's own (a walk bends 10, a run 70) |
 | `kneeLift` | multiplies | 1 | knee lift; below 1 drags the feet, above it high-steps; the foot angles follow |
 | `sway` | adds | 0 | hip yaw in degrees, alternating with the step, the shoulders countering by half |
@@ -667,8 +668,8 @@ swinging over a slightly longer, slower step; `march` is high knees, a wide
 arm swing, straight elbows and a straight back.
 
 `furious` is short, hard, quick steps with the knees stamping, the shoulders
-hunched over a forward head and the fists carried before the chest by a bent
-elbow - not a bigger walk. Two earlier versions of it were: one slid the whole
+hunched over a forward head, the upper arms carried off the ribs and the fists
+before the chest by a bent elbow - not a bigger walk. Two earlier versions of it were: one slid the whole
 arm swing 22 degrees forward, the other folded the elbow to 80, and both put
 the forearms out in front where they barely alternated, which reads as a
 sleepwalker from every angle. The cycle sheet is what settled it. A name that is not in the list does nothing

--- a/plugins/clay_character3d/animation/FightAnim.qml
+++ b/plugins/clay_character3d/animation/FightAnim.qml
@@ -20,8 +20,19 @@ ProceduralAnim {
     readonly property real punchUpperArm: 75 + intensity * 10       // Arm extends forward horizontally (75-85)
     readonly property real punchElbow: 15 + intensity * 10          // Nearly straight arm (15-25)
 
-    // Torso rotation during punch
+    // Torso rotation during punch. It is shared: the trunk group turns the
+    // hips and the legs with it, the chest turns further on the waist joint.
+    // A punch that came entirely from the group swung the feet round with the
+    // shoulders; the shoulders arriving ahead of the hips is what a thrown
+    // punch looks like, and it keeps the stance planted.
     readonly property real torsoTwist: 15 + intensity * 10          // 15-25 degrees
+    readonly property real hipTwist: torsoTwist * 0.4
+    readonly property real chestTwist: torsoTwist * 0.6
+
+    // The guard is a rolled-forward chest over a level lower back: shoulders
+    // up and in, chin behind them. On the chest alone, so the legs stay where
+    // the stance put them.
+    readonly property real guardChestLean: 8
 
     // Athletic stance - slight crouch
     readonly property real kneeBend: 10 + intensity * 5             // 10-15 degrees
@@ -35,12 +46,18 @@ ProceduralAnim {
 
     // Phase 1: Guard stance (both fists in front of face)
     ParallelAnimation {
-        // Torso centered
+        // Torso centered, chest rolled forward over the guard
         EulerAnim {
             target: entity.torso
             duration: guardDuration
-            from: Qt.vector3d(0, -torsoTwist, 0)
+            from: Qt.vector3d(0, -hipTwist, 0)
             to: Qt.vector3d(0, 0, 0)
+        }
+        EulerAnim {
+            target: entity.chest
+            duration: guardDuration
+            from: Qt.vector3d(guardChestLean, -chestTwist, 0)
+            to: Qt.vector3d(guardChestLean, 0, 0)
         }
 
         // Right arm in guard - fist in front of face
@@ -104,12 +121,18 @@ ProceduralAnim {
 
     // Phase 2: Right punch - horizontal forward strike
     ParallelAnimation {
-        // Torso rotates into punch
+        // Torso rotates into punch - the chest leads, the hips follow
         EulerAnim {
             target: entity.torso
             duration: _fightAnim.duration
             from: Qt.vector3d(0, 0, 0)
-            to: Qt.vector3d(0, torsoTwist, 0)
+            to: Qt.vector3d(0, hipTwist, 0)
+        }
+        EulerAnim {
+            target: entity.chest
+            duration: _fightAnim.duration
+            from: Qt.vector3d(guardChestLean, 0, 0)
+            to: Qt.vector3d(guardChestLean, chestTwist, 0)
         }
 
         // Right arm extends forward horizontally
@@ -167,8 +190,14 @@ ProceduralAnim {
         EulerAnim {
             target: entity.torso
             duration: guardDuration
-            from: Qt.vector3d(0, torsoTwist, 0)
+            from: Qt.vector3d(0, hipTwist, 0)
             to: Qt.vector3d(0, 0, 0)
+        }
+        EulerAnim {
+            target: entity.chest
+            duration: guardDuration
+            from: Qt.vector3d(guardChestLean, chestTwist, 0)
+            to: Qt.vector3d(guardChestLean, 0, 0)
         }
 
         // Right arm back to guard
@@ -227,7 +256,13 @@ ProceduralAnim {
             target: entity.torso
             duration: _fightAnim.duration
             from: Qt.vector3d(0, 0, 0)
-            to: Qt.vector3d(0, -torsoTwist, 0)
+            to: Qt.vector3d(0, -hipTwist, 0)
+        }
+        EulerAnim {
+            target: entity.chest
+            duration: _fightAnim.duration
+            from: Qt.vector3d(guardChestLean, 0, 0)
+            to: Qt.vector3d(guardChestLean, -chestTwist, 0)
         }
 
         // Right arm in guard

--- a/plugins/clay_character3d/animation/GaitCycleAnim.qml
+++ b/plugins/clay_character3d/animation/GaitCycleAnim.qml
@@ -209,12 +209,15 @@ ProceduralAnim {
             to: Qt.vector3d(_cycle.table.footDown, 0, 0)
         }
 
-        // The arm on the leading leg's side goes back
+        // The arm on the leading leg's side goes back. The outward roll is
+        // signed by the SIDE, and `s` is it: phase 1 leads with the right arm
+        // and phase 2 with the left, so `s` on the lead and `-s` on the trail
+        // is +armOut on the right arm and -armOut on the left in both.
         EulerAnim {
             target: _step.leadArm.upperArm
             duration: _cycle.duration
-            from: Qt.vector3d(-_cycle.table.armFwd, 0, 0)
-            to: Qt.vector3d(_cycle.table.armBack, 0, 0)
+            from: Qt.vector3d(-_cycle.table.armFwd, 0, _cycle.table.armOut * _step.s)
+            to: Qt.vector3d(_cycle.table.armBack, 0, _cycle.table.armOut * _step.s)
         }
         EulerAnim {
             target: _step.leadArm.lowerArm
@@ -227,8 +230,8 @@ ProceduralAnim {
         EulerAnim {
             target: _step.trailArm.upperArm
             duration: _cycle.duration
-            from: Qt.vector3d(_cycle.table.armBack, 0, 0)
-            to: Qt.vector3d(-_cycle.table.armFwd, 0, 0)
+            from: Qt.vector3d(_cycle.table.armBack, 0, -_cycle.table.armOut * _step.s)
+            to: Qt.vector3d(-_cycle.table.armFwd, 0, -_cycle.table.armOut * _step.s)
         }
         EulerAnim {
             target: _step.trailArm.lowerArm

--- a/plugins/clay_character3d/animation/GaitCycleAnim.qml
+++ b/plugins/clay_character3d/animation/GaitCycleAnim.qml
@@ -107,8 +107,8 @@ ProceduralAnim {
     // One step. `lead` is the leg swinging forward this phase and `trail` the
     // one pushing back; the arms oppose their legs. Sign conventions are the
     // joints' own: positive x pitches forward and down, so a forward limb is
-    // negative x. Sway is a hip yaw with the torso countering by half, rock a
-    // torso roll over the planted leg; `s` flips both between the phases.
+    // negative x. Sway is a hip yaw with the trunk countering by half, rock a
+    // trunk roll over the planted leg; `s` flips both between the phases.
     component Step: ParallelAnimation {
         id: _step
         required property var lead
@@ -117,20 +117,33 @@ ProceduralAnim {
         required property var trailArm
         required property real s
 
-        // Posture: lean and head hold, sway and rock alternate.
+        // Posture. The trunk group turns and rolls the whole upper body; the
+        // pitch is not here, it is in the two spine segments below, whose
+        // angles sum to the table's lean and whose difference is the curve of
+        // the back. Sway and rock alternate with the step, lean and curve hold.
         EulerAnim {
             target: entity.torso
             duration: _cycle.duration
-            to: Qt.vector3d(_cycle.table.lean,
+            to: Qt.vector3d(0,
                             _cycle.table.sway * 0.5 * _step.s,
                             _cycle.table.rock * _step.s)
         }
-        // The hip hangs off the torso, so it counters the waist share of the
-        // lean - legs stay planted while the chest tips - and carries the sway.
+        EulerAnim {
+            target: entity.belly
+            duration: _cycle.duration
+            to: Qt.vector3d(_cycle.table.bellyLean, 0, 0)
+        }
+        EulerAnim {
+            target: entity.chest
+            duration: _cycle.duration
+            to: Qt.vector3d(_cycle.table.chestLean, 0, 0)
+        }
+        // The hip hangs off the belly, so it gives back the belly's bend -
+        // legs stay planted while the back rounds - and carries the sway.
         EulerAnim {
             target: entity.hip
             duration: _cycle.duration
-            to: Qt.vector3d(-_cycle.table.waistLean, -_cycle.table.sway * _step.s, 0)
+            to: Qt.vector3d(_cycle.table.hipLean, -_cycle.table.sway * _step.s, 0)
         }
         HeadEulerAnim {
             target: entity.head

--- a/plugins/clay_character3d/animation/GestureAnim.qml
+++ b/plugins/clay_character3d/animation/GestureAnim.qml
@@ -543,6 +543,16 @@ Node {
     // Taken once per gesture, not per re-aim, so switching targets while
     // pointing still knows where "released" was. turnTo() moves it.
     property vector3d _restEuler: Qt.vector3d(0, 0, 0)
+
+    // How a beat's `lean` reaches the body. It used to be a pitch on the
+    // character's own node, which tipped the FEET with the shoulders by a
+    // degree or two - cheap, and wrong: a speaker leaning in bends, it does
+    // not fall toward the listener. On the waist joint the same number buys
+    // more, because nothing below the belt moves with it, so it is scaled up
+    // and given a curve: the chest comes forward over a lower back that
+    // barely moves.
+    readonly property real _talkLeanScale: 2.4
+    readonly property real _talkLeanCurve: 1.2
     property bool _holdsRoot: false
 
     // restart() stops before it starts, and that stop must not be mistaken
@@ -740,9 +750,10 @@ Node {
             // facing, not a facing of their own, which is why they are added
             // to the rest orientation rather than replacing it - a talking
             // body that decided where to look would fight turnTo() and win.
-            _pose.rootEuler = Qt.vector3d(root._restEuler.x + b.lean,
+            _pose.rootEuler = Qt.vector3d(root._restEuler.x,
                                           root._restEuler.y + b.turn,
                                           root._restEuler.z)
+            _pose.spine(b.lean * root._talkLeanScale, b.lean * root._talkLeanCurve)
             _pose.gesticulate(root._talkUpper(b.rUp, b.rOut, 1),
                               root._talkLower(b.rEl),
                               root._talkWrist(b.rWr, b.rRo, 1),
@@ -944,6 +955,13 @@ Node {
         // which it is.
         property string mode: ""
         property vector3d rootEuler: Qt.vector3d(0, 0, 0)
+        // The waist joint: the two trunk segments, straight unless a beat
+        // bends them. Their pitches add up to the lean that was asked for and
+        // their difference is how round the back is - the same split the gait
+        // model makes, so a character that leans while it talks and a
+        // character that leans while it walks bend the same way.
+        property vector3d belly: Qt.vector3d(0, 0, 0)
+        property vector3d chest: Qt.vector3d(0, 0, 0)
         property vector3d head: Qt.vector3d(0, 0, 0)
         property vector3d rUpper: Qt.vector3d(0, 0, 0)
         property vector3d rLower: Qt.vector3d(0, 0, 0)
@@ -961,10 +979,18 @@ Node {
 
         readonly property vector3d zero: Qt.vector3d(0, 0, 0)
 
+        // lean is the total forward pitch of the trunk, curve how much of it
+        // is a bend rather than a tilt.
+        function spine(lean, curve) {
+            belly = Qt.vector3d(lean * 0.4 - curve * 0.5, 0, 0)
+            chest = Qt.vector3d(lean * 0.6 + curve * 0.5, 0, 0)
+        }
+
         function aim(what, which, upper, lower, wrist, look) {
             side = which
             mode = what
             head = look
+            belly = zero; chest = zero
             rPose = ""; lPose = ""
             rUpper = which > 0 ? upper : zero
             rLower = which > 0 ? lower : zero
@@ -993,6 +1019,7 @@ Node {
             mode = "look"
             rootEuler = rest
             head = look
+            belly = zero; chest = zero
             rPose = ""; lPose = ""
             rUpper = zero; rLower = zero; rHand = zero
             lUpper = zero; lLower = zero; lHand = zero
@@ -1028,6 +1055,18 @@ Node {
             duration: root._msBody
             easing.type: root._moveEase
             to: _pose.rootEuler
+        }
+        EulerAnim {
+            target: root.entity ? root.entity.belly : null
+            duration: root._msBody
+            easing.type: root._moveEase
+            to: _pose.belly
+        }
+        EulerAnim {
+            target: root.entity ? root.entity.chest : null
+            duration: root._msBody
+            easing.type: root._moveEase
+            to: _pose.chest
         }
         HeadEulerAnim {
             target: root.entity ? root.entity.head : null

--- a/plugins/clay_character3d/animation/IdleAnim.qml
+++ b/plugins/clay_character3d/animation/IdleAnim.qml
@@ -4,10 +4,23 @@ ProceduralAnim {
     id: _idleAnim
 
     ParallelAnimation {
-        // Reset torso to upright
+        // Reset the trunk to upright - the group, and the two spine segments
+        // under it. A gait that rounded the back leaves the curve in the
+        // belly and the chest, not in the group, so zeroing the group alone
+        // would let a character stand still with a slump it never asked for.
         EulerAnim {
             duration: _idleAnim.duration
             target: entity.torso
+            to: Qt.vector3d(0, 0, 0)
+        }
+        EulerAnim {
+            duration: _idleAnim.duration
+            target: entity.belly
+            to: Qt.vector3d(0, 0, 0)
+        }
+        EulerAnim {
+            duration: _idleAnim.duration
+            target: entity.chest
             to: Qt.vector3d(0, 0, 0)
         }
 

--- a/plugins/clay_character3d/animation/TalkGestureAnim.qml
+++ b/plugins/clay_character3d/animation/TalkGestureAnim.qml
@@ -22,9 +22,18 @@ ProceduralAnim {
     // Pace: sad drags, angry is agitated
     duration: _sad ? 1400 : _angry ? 400 : 650
 
-    // Posture
+    // Posture. The lean is shared over the waist joint the same way a gait's
+    // is: the two segments add up to torsoLean, and the curve between them is
+    // what makes a sad speaker read as slumped rather than tipped. The twist
+    // is shared too - the chest turns further than the hips, which is what a
+    // person talking with their hands actually does.
     readonly property real torsoLean: _sad ? 9 : _angry ? 5 : -2
+    readonly property real spineCurve: _sad ? 13 : _angry ? 5 : _happy ? -7 : -3
+    readonly property real bellyLean: torsoLean * 0.4 - spineCurve * 0.5
+    readonly property real chestLean: torsoLean * 0.6 + spineCurve * 0.5
     readonly property real torsoTwist: _angry ? 5 : _happy ? 2 : 1
+    readonly property real hipTwist: torsoTwist * 0.35
+    readonly property real chestTwist: torsoTwist * 0.65
     readonly property real headTilt: _sad ? 15 : _angry ? 6 : -2
     readonly property real headSway: _happy ? 7 : _sad ? 2 : 0
 
@@ -40,7 +49,17 @@ ProceduralAnim {
         EulerAnim {
             target: entity.torso
             duration: _gesture.duration
-            to: Qt.vector3d(torsoLean, torsoTwist, 0)
+            to: Qt.vector3d(0, hipTwist, 0)
+        }
+        EulerAnim {
+            target: entity.belly
+            duration: _gesture.duration
+            to: Qt.vector3d(bellyLean, 0, 0)
+        }
+        EulerAnim {
+            target: entity.chest
+            duration: _gesture.duration
+            to: Qt.vector3d(chestLean, chestTwist, 0)
         }
         HeadEulerAnim {
             target: entity.head
@@ -74,7 +93,17 @@ ProceduralAnim {
         EulerAnim {
             target: entity.torso
             duration: _gesture.duration
-            to: Qt.vector3d(torsoLean, -torsoTwist, 0)
+            to: Qt.vector3d(0, -hipTwist, 0)
+        }
+        EulerAnim {
+            target: entity.belly
+            duration: _gesture.duration
+            to: Qt.vector3d(bellyLean, 0, 0)
+        }
+        EulerAnim {
+            target: entity.chest
+            duration: _gesture.duration
+            to: Qt.vector3d(chestLean, -chestTwist, 0)
         }
         HeadEulerAnim {
             target: entity.head

--- a/plugins/clay_character3d/animation/UseAnim.qml
+++ b/plugins/clay_character3d/animation/UseAnim.qml
@@ -13,8 +13,15 @@ ProceduralAnim {
     property real intensity: 0.5        // 0=subtle, 1=vigorous movements
 
     // Derived angles based on workHeight
-    // Upper body lean (hip counter-rotates to keep legs upright)
+    // Upper body lean. It is shared between the two spine segments, and the
+    // chest takes more than its share so the back ROUNDS over the work rather
+    // than tipping as one board; the hip gives the belly's part straight back
+    // so the legs stay upright. The three still add up to torsoLean, so the
+    // head and hands arrive exactly where they used to.
     readonly property real torsoLean: 10 + intensity * 5                    // 10-15 degrees forward
+    readonly property real spineCurve: 8                                     // how round the back gets
+    readonly property real bellyLean: torsoLean * 0.4 - spineCurve * 0.5
+    readonly property real chestLean: torsoLean * 0.6 + spineCurve * 0.5
     readonly property real headTilt: 15 + intensity * 10                    // 15-25 degrees down
 
     // Upper arm angles: forward reach + downward angle based on work height
@@ -38,20 +45,32 @@ ProceduralAnim {
 
     // Phase 1: Right hand down, left hand up (working motion)
     ParallelAnimation {
-        // Torso leaning forward (upper body only)
+        // Torso leaning forward (upper body only), bent over the spine
         EulerAnim {
             target: entity.torso
             duration: _useAnim.duration
-            from: Qt.vector3d(torsoLean, 0, 0)
-            to: Qt.vector3d(torsoLean, 0, 0)
+            from: Qt.vector3d(0, 0, 0)
+            to: Qt.vector3d(0, 0, 0)
+        }
+        EulerAnim {
+            target: entity.belly
+            duration: _useAnim.duration
+            from: Qt.vector3d(bellyLean, 0, 0)
+            to: Qt.vector3d(bellyLean, 0, 0)
+        }
+        EulerAnim {
+            target: entity.chest
+            duration: _useAnim.duration
+            from: Qt.vector3d(chestLean, 0, 0)
+            to: Qt.vector3d(chestLean, 0, 0)
         }
 
         // Hip counter-rotates to keep legs upright
         EulerAnim {
             target: entity.hip
             duration: _useAnim.duration
-            from: Qt.vector3d(-torsoLean, 0, 0)
-            to: Qt.vector3d(-torsoLean, 0, 0)
+            from: Qt.vector3d(-bellyLean, 0, 0)
+            to: Qt.vector3d(-bellyLean, 0, 0)
         }
 
         // Head looking down at work
@@ -131,16 +150,28 @@ ProceduralAnim {
         EulerAnim {
             target: entity.torso
             duration: _useAnim.duration
-            from: Qt.vector3d(torsoLean, 0, 0)
-            to: Qt.vector3d(torsoLean, 0, 0)
+            from: Qt.vector3d(0, 0, 0)
+            to: Qt.vector3d(0, 0, 0)
+        }
+        EulerAnim {
+            target: entity.belly
+            duration: _useAnim.duration
+            from: Qt.vector3d(bellyLean, 0, 0)
+            to: Qt.vector3d(bellyLean, 0, 0)
+        }
+        EulerAnim {
+            target: entity.chest
+            duration: _useAnim.duration
+            from: Qt.vector3d(chestLean, 0, 0)
+            to: Qt.vector3d(chestLean, 0, 0)
         }
 
         // Hip stays counter-rotated
         EulerAnim {
             target: entity.hip
             duration: _useAnim.duration
-            from: Qt.vector3d(-torsoLean, 0, 0)
-            to: Qt.vector3d(-torsoLean, 0, 0)
+            from: Qt.vector3d(-bellyLean, 0, 0)
+            to: Qt.vector3d(-bellyLean, 0, 0)
         }
 
         // Head stays looking down

--- a/plugins/clay_character3d/animation/gait.js
+++ b/plugins/clay_character3d/animation/gait.js
@@ -38,6 +38,12 @@ var FACTORS = {
     stride:    { kind: "mul", neutral: 1, min: 0.3, max: 1.6 },
     bounce:    { kind: "add", neutral: 0, min: 0,   max: 0.1 },
     lean:      { kind: "add", neutral: 0, min: -30, max: 30 },
+    // How much of the trunk's bend is a CURVE rather than a tilt: the angle
+    // between belly and chest, positive rounding the back forward, negative
+    // arching it and lifting the chest. Differential on purpose - it changes
+    // the shape of the spine without moving where the head ends up, which is
+    // lean's job. A slump is lean AND spineCurve; a plank is lean alone.
+    spineCurve:{ kind: "add", neutral: 0, min: -25, max: 30 },
     headPitch: { kind: "add", neutral: 0, min: -40, max: 40 },
     armSwing:  { kind: "mul", neutral: 1, min: 0,   max: 2 },
     armForward:{ kind: "add", neutral: 0, min: -30, max: 60 },
@@ -127,13 +133,36 @@ var BASES = {
 // emotion is worn on top of a build, not instead of one.
 var EMOTIONS = {
     // Happy is the arms: the bounce is there but it is the big swing that
-    // says "I am so happy" - the arms go well past the hips both ways.
-    happy: { tempo: 1.12, bounce: 0.04, armSwing: 1.7, elbow: 6, kneeLift: 1.12, headPitch: -5, lean: -2 },
-    sad:   { tempo: 0.82, stride: 0.82, armSwing: 0.55, kneeLift: 0.75, headPitch: 16, lean: 7, elbow: 4 },
-    // Angry is arms half bent and carried IN FRONT: the swing's centre moves
-    // ahead of the body (armForward), so the fists pump before the chest,
-    // ready to hit, rather than swinging past the hips like a walk.
-    angry: { tempo: 1.15, stride: 1.08, lean: 9, armSwing: 1.3, elbow: 45, armForward: 22, kneeLift: 1.08, headPitch: 5, rock: 2 }
+    // says "I am so happy" - the arms go well past the hips both ways. The
+    // chest is open, so the spine arches rather than rounds.
+    happy: { tempo: 1.12, bounce: 0.075, armSwing: 1.7, elbow: 6, kneeLift: 1.25, headPitch: -8, lean: -2, spineCurve: -7 },
+    // Sad is the back. The lean alone made a plank tip; the curve is what
+    // makes it read as weight - the belly settles back, the chest rounds
+    // forward over it, and the head hangs off the end of that curve.
+    sad:   { tempo: 0.82, stride: 0.82, armSwing: 0.45, kneeLift: 0.75, headPitch: 20, lean: 7, elbow: 4, spineCurve: 14 },
+    // Angry is SHORT, HARD steps with the arms held in - not a big swing.
+    // The first version swung the arms half again as far as a walk and
+    // carried them 22 degrees forward on top, which came out as a lope with
+    // the forearms flapping across the chest; a stride longer than a neutral
+    // walk made it worse, because ground covered easily is the opposite of
+    // what anger looks like. So: quicker and shorter (tempo up, stride down),
+    // the knees stamping, the shoulders hunched over a forward head - the
+    // bull, not the strider.
+    //
+    // The arms are the part that had to be measured on a sheet rather than
+    // reasoned about. Sliding the whole swing 22 degrees forward put both
+    // upper arms ahead of the body at once and left them barely alternating -
+    // a sleepwalker from every angle. Folding the elbow to 80 instead put
+    // both forearms out horizontally, which is the same silhouette by another
+    // route, and it left the arms swinging at the hips with no attitude at
+    // all. What works is a NORMAL swing with a hard bend and almost no
+    // forward bias: the upper arms still pass each other, so the swing reads
+    // head-on as well as in profile, and 65 degrees of elbow carries the
+    // fists from in front of the hip to in front of the chest and back -
+    // which is the pumping the forward bias was reaching for and could not
+    // make without folding the silhouette flat.
+    angry: { tempo: 1.22, stride: 0.92, lean: 11, spineCurve: 6, armSwing: 1.0, elbow: 55,
+             armForward: 4, kneeLift: 1.25, headPitch: 7, rock: 4, bounce: 0.015 }
 }
 
 function canonicalEmotion(e) {
@@ -152,14 +181,25 @@ function emotionFactors(emotion) {
 // The two ends of the maturity slider, and the four build directions. Each is
 // the FULL effect; buildFactors() fades them in over the slider's zone.
 var BUILD = {
-    child:     { tempo: 1.22, stride: 0.92, kneeLift: 1.3, bounce: 0.025, armSwing: 1.2 },
-    elderly:   { tempo: 0.72, stride: 0.72, kneeLift: 0.6, lean: 8, headPitch: 12, elbow: 12, armSwing: 0.5 },
-    feminine:  { sway: 9, armSwing: 0.8, elbow: 6, stride: 0.95 },
-    masculine: { rock: 2, armSwing: 1.15, stride: 1.05 },
-    heavy:     { tempo: 0.82, stride: 0.86, rock: 6, elbow: 4, kneeLift: 0.9, lean: 2 },
+    // A small child stands with the belly forward and the back arched, not
+    // slumped - the spine curve is negative for the same reason the lean is.
+    child:     { tempo: 1.22, stride: 0.92, kneeLift: 1.3, bounce: 0.025, armSwing: 1.2,
+                 lean: -3, spineCurve: -8 },
+    // Deliberately further from `sad` than the numbers first were: on a cycle
+    // sheet the two came out as the same slouch, and the thing that separates
+    // them is not more sadness, it is the feet. Age is short careful steps
+    // that barely leave the ground.
+    elderly:   { tempo: 0.72, stride: 0.60, kneeLift: 0.45, lean: 8, headPitch: 15, elbow: 18,
+                 armSwing: 0.45, spineCurve: 18 },
+    feminine:  { sway: 9, armSwing: 0.8, elbow: 6, stride: 0.95, spineCurve: -3 },
+    masculine: { rock: 2, armSwing: 1.15, stride: 1.05, spineCurve: 2 },
+    // Weight in front has to be counterbalanced behind: a heavy walker leans
+    // BACK and leads with the belly. The old forward 2 degrees fought the
+    // gut it was supposed to be carrying.
+    heavy:     { tempo: 0.82, stride: 0.86, rock: 6, elbow: 4, kneeLift: 0.9, lean: -3, spineCurve: -3 },
     light:     { tempo: 1.06, bounce: 0.01 },
-    athletic:  { lean: 3, armSwing: 1.15, tempo: 1.05, elbow: 8 },
-    soft:      { lean: 4, headPitch: 4, armSwing: 0.85 }
+    athletic:  { lean: 3, armSwing: 1.15, tempo: 1.05, elbow: 8, spineCurve: -4 },
+    soft:      { lean: 4, headPitch: 4, armSwing: 0.85, spineCurve: 6 }
 }
 
 // build: { maturity, femininity, mass, muscle }, each 0..1, 0.5 = neutral.
@@ -207,9 +247,14 @@ var PRESETS = {
     elderly:  BUILD.elderly,
     toddler:  compose([BUILD.child, { tempo: 1.1 }]),
     heavy:    compose([BUILD.heavy, { rock: 2 }]),
-    sneak:    { tempo: 0.7, stride: 0.7, kneeLift: 1.5, lean: 12, headPitch: 8, elbow: 26, armSwing: 0.5 },
-    proud:    { tempo: 0.92, stride: 1.08, lean: -7, headPitch: -9, armSwing: 1.25, elbow: 8 },
-    march:    { kneeLift: 1.7, armSwing: 1.5, lean: -3, bounce: 0.015, elbow: -10 }
+    sneak:    { tempo: 0.7, stride: 0.7, kneeLift: 1.5, lean: 12, headPitch: 8, elbow: 26,
+                armSwing: 0.5, spineCurve: 12 },
+    // Proud is the chest, and the chest is a NEGATIVE curve: the back arches,
+    // the ribs come up and forward, the shoulders go back. A backward lean on
+    // its own only makes a figure recline.
+    proud:    { tempo: 0.92, stride: 1.08, lean: -7, headPitch: -9, armSwing: 1.25, elbow: 8,
+                spineCurve: -12 },
+    march:    { kneeLift: 1.7, armSwing: 1.5, lean: -3, bounce: 0.015, elbow: -10, spineCurve: -6 }
 }
 
 var PRESET_NAMES = Object.keys(PRESETS)
@@ -226,6 +271,39 @@ function presetFactors(name) {
 
 // --- derivation ---------------------------------------------------------------
 
+// How a trunk bend is shared between the two spine segments.
+//
+// BELLY_SHARE is the belly's part of the total tilt; the chest takes the rest
+// on top of it, so the head still ends up tipped by exactly `lean` and the
+// foot placement the speed is derived from is untouched. The chest gets the
+// larger share because that is where a slump reads - the upper back is what
+// an audience sees round.
+//
+// AUTO_CURVE turns part of a FACTOR lean into curvature on its own: a
+// character asked to lean 8 degrees bends over its spine instead of tipping
+// like a plank, which is the whole reason the trunk was split.
+//
+// A BASE lean is different and gets none of this. A run's 12 degrees is a
+// sprinter's straight line from the ankles: the whole figure tips, legs
+// included, and the waist joint stays shut. It goes on the belly alone, with
+// nothing at the joint - the first version shared it like a factor lean and
+// put a seven-degree kink in the middle of every runner's back.
+var BELLY_SHARE = 0.4
+var AUTO_CURVE = 0.5
+
+// The two spine angles. `baseLean` tips the trunk rigidly; `waistLean` is
+// shared between the segments; `curve` is differential - it bends the belly
+// back by as much as it bends the chest forward, so it changes the shape of
+// the trunk without moving the head. belly + chest is always
+// baseLean + waistLean.
+function spineFrom(baseLean, waistLean, curve) {
+    var half = 0.5 * (curve + AUTO_CURVE * waistLean)
+    return {
+        belly: clamp(baseLean + waistLean * BELLY_SHARE - half, -45, 45),
+        chest: clamp(waistLean * (1 - BELLY_SHARE) + half, -45, 45)
+    }
+}
+
 // The table a cycle animates from. Joint limits here are geometric: whatever
 // the factors say, a knee does not pass 150 degrees and a hip does not swing
 // past 80, and a cycle shorter than a quarter second or longer than two is a
@@ -235,6 +313,12 @@ function derive(baseName, factors) {
     var f = factors || neutral()
     function get(k) { var v = Number(f[k]); return isFinite(v) ? v : FACTORS[k].neutral }
     var kneeK = get("kneeLift")
+    // The trunk, solved once: the total tilt, the share of it that pivots at
+    // the waist, and the curve the two segments take.
+    var lean = clamp(b.lean + get("lean"), -30, 40)
+    var waistLean = clamp(get("lean"), -30, 30)
+    var curve = clamp(get("spineCurve"), -25, 30)
+    var spine = spineFrom(b.lean, waistLean, curve)
     return {
         base: BASES[baseName] ? baseName : "walk",
         cycleMs: clamp(b.cycleMs / get("tempo"), 250, 2000),
@@ -250,13 +334,25 @@ function derive(baseName, factors) {
         armFwd: clamp(b.armFwd * get("armSwing") + get("armForward"), 0, 110),
         armBack: clamp(b.armBack * get("armSwing") - get("armForward"), -60, 90),
         elbow: clamp(b.elbow + get("elbow"), 0, 140),
-        lean: clamp(b.lean + get("lean"), -30, 40),
+        lean: lean,
         // The factor's share of the lean pivots at the WAIST: the hip counters
         // it so the legs stay planted and only chest, head and arms tip. The
         // base's own lean (a run's 12) stays whole-body - a sprinter leans
         // with everything, a slump bends. Without this a sad character rotates
         // like a plank about its waist and looks about to fall on its face.
-        waistLean: clamp(get("lean"), -30, 30),
+        waistLean: waistLean,
+        // The trunk is two segments on a waist joint, so the tilt above is
+        // reported as the pair of angles the segments actually take. Their
+        // sum is `lean`; their difference is how round the back is.
+        bellyLean: spine.belly,
+        chestLean: spine.chest,
+        spineCurve: curve,
+        // What the hip does about all that. The pelvis hangs off the BELLY, so
+        // it only ever sees the belly's share of the tilt, and it gives back
+        // exactly enough of it to leave the legs where the base asked for
+        // them: standing upright under a factor lean, tipped with the whole
+        // figure under a run's.
+        hipLean: b.lean - spine.belly,
         headPitch: clamp(get("headPitch"), -40, 40),
         bounce: clamp(get("bounce"), 0, 0.1),
         sway: clamp(get("sway"), 0, 20),
@@ -305,12 +401,14 @@ function liftAt(u) {
 }
 
 // Joint angles at phase t of the cycle, 0..1, as the cycle animation would
-// have them. The hip is a child of the torso, so its pitch is the counter to
-// the waist lean and its yaw the sway. t in [0, 0.5) is the first phase (right leg swinging forward),
+// have them. The hip is a child of the belly, so its pitch is the counter to
+// the belly's bend and its yaw the sway. t in [0, 0.5) is the first phase (right leg swinging forward),
 // [0.5, 1) the second; t = 1 is t = 0 again. Angles follow the joints' own
 // conventions: positive x pitches forward and down, so a forward leg or arm is
-// negative x. Legs and arms are {upper, lower, foot|hand}; torso, hip and head
-// are [x, y, z]; lift is in leg heights.
+// negative x. Legs and arms are {upper, lower, foot|hand}; torso, belly, chest,
+// hip and head are [x, y, z]; lift is in leg heights. belly and chest are the
+// two halves of the trunk on either side of the waist joint: their pitches sum
+// to the table's lean and their difference is how round the back is.
 function poseAt(table, t) {
     t = t - Math.floor(t)
     var second = t >= 0.5
@@ -350,8 +448,14 @@ function poseAt(table, t) {
         leftLeg: second ? fwd : back,
         rightArm: second ? armFwd : armBack,
         leftArm: second ? armBack : armFwd,
-        hip: [-table.waistLean, yaw, 0],
-        torso: [table.lean, -yaw * 0.5, roll],
+        hip: [table.hipLean, yaw, 0],
+        // The trunk group carries no pitch of its own any more: the tilt
+        // lives in the two spine segments below it, whose angles add up to
+        // table.lean. Sway and rock stay here, where they turn and roll the
+        // whole trunk over the planted leg.
+        torso: [0, -yaw * 0.5, roll],
+        belly: [table.bellyLean, 0, 0],
+        chest: [table.chestLean, 0, 0],
         head: [table.headPitch, 0, 0],
         lift: table.bounce * liftAt(second ? (t - 0.5) * 2 : t * 2)
     }

--- a/plugins/clay_character3d/animation/gait.js
+++ b/plugins/clay_character3d/animation/gait.js
@@ -47,6 +47,12 @@ var FACTORS = {
     headPitch: { kind: "add", neutral: 0, min: -40, max: 40 },
     armSwing:  { kind: "mul", neutral: 1, min: 0,   max: 2 },
     armForward:{ kind: "add", neutral: 0, min: -30, max: 60 },
+    // How far the upper arms are held OUT from the ribs, in degrees. The
+    // cycle swung them fore and aft and nothing else, so every gait had the
+    // arms glued to the sides whatever else it was doing - which is why an
+    // angry walk could not be told from a hurried one head-on. Held through
+    // the cycle rather than alternating: it is a carriage, not a movement.
+    armOut:    { kind: "add", neutral: 0, min: 0,   max: 45 },
     elbow:     { kind: "add", neutral: 0, min: -10, max: 80 },
     kneeLift:  { kind: "mul", neutral: 1, min: 0.3, max: 2 },
     sway:      { kind: "add", neutral: 0, min: 0,   max: 20 },
@@ -155,14 +161,21 @@ var EMOTIONS = {
     // a sleepwalker from every angle. Folding the elbow to 80 instead put
     // both forearms out horizontally, which is the same silhouette by another
     // route, and it left the arms swinging at the hips with no attitude at
-    // all. What works is a NORMAL swing with a hard bend and almost no
+    // all. What works is a NORMAL swing with a hard bend and a small
     // forward bias: the upper arms still pass each other, so the swing reads
     // head-on as well as in profile, and 65 degrees of elbow carries the
     // fists from in front of the hip to in front of the chest and back -
     // which is the pumping the forward bias was reaching for and could not
     // make without folding the silhouette flat.
+    //
+    // armOut is the other half of it, and the cycle had no way to say it: the
+    // upper arms are carried thirteen degrees off the ribs, which is what
+    // makes a body look ready to hit something rather than in a hurry. The
+    // rock went back down to 2 at the same time - a trunk rolling four
+    // degrees each way at this tempo reads as a waddle, and side-to-side
+    // weight is the HEAVY cue anyway, not the angry one.
     angry: { tempo: 1.22, stride: 0.92, lean: 11, spineCurve: 6, armSwing: 1.0, elbow: 55,
-             armForward: 4, kneeLift: 1.25, headPitch: 7, rock: 4, bounce: 0.015 }
+             armForward: 8, armOut: 13, kneeLift: 1.25, headPitch: 7, rock: 2, bounce: 0.015 }
 }
 
 function canonicalEmotion(e) {
@@ -196,7 +209,8 @@ var BUILD = {
     // Weight in front has to be counterbalanced behind: a heavy walker leans
     // BACK and leads with the belly. The old forward 2 degrees fought the
     // gut it was supposed to be carrying.
-    heavy:     { tempo: 0.82, stride: 0.86, rock: 6, elbow: 4, kneeLift: 0.9, lean: -3, spineCurve: -3 },
+    heavy:     { tempo: 0.82, stride: 0.86, rock: 6, elbow: 4, kneeLift: 0.9, lean: -3,
+                 spineCurve: -3, armOut: 7 },
     light:     { tempo: 1.06, bounce: 0.01 },
     athletic:  { lean: 3, armSwing: 1.15, tempo: 1.05, elbow: 8, spineCurve: -4 },
     soft:      { lean: 4, headPitch: 4, armSwing: 0.85, spineCurve: 6 }
@@ -333,6 +347,7 @@ function derive(baseName, factors) {
         // arm never gets behind the hip at all.
         armFwd: clamp(b.armFwd * get("armSwing") + get("armForward"), 0, 110),
         armBack: clamp(b.armBack * get("armSwing") - get("armForward"), -60, 90),
+        armOut: clamp(get("armOut"), 0, 45),
         elbow: clamp(b.elbow + get("elbow"), 0, 140),
         lean: lean,
         // The factor's share of the lean pivots at the WAIST: the hip counters
@@ -405,7 +420,8 @@ function liftAt(u) {
 // the belly's bend and its yaw the sway. t in [0, 0.5) is the first phase (right leg swinging forward),
 // [0.5, 1) the second; t = 1 is t = 0 again. Angles follow the joints' own
 // conventions: positive x pitches forward and down, so a forward leg or arm is
-// negative x. Legs and arms are {upper, lower, foot|hand}; torso, belly, chest,
+// negative x. Legs are {upper, lower, foot}, arms {upper, lower, out} with out
+// the roll that carries them away from the ribs; torso, belly, chest,
 // hip and head are [x, y, z]; lift is in leg heights. belly and chest are the
 // two halves of the trunk on either side of the waist joint: their pitches sum
 // to the table's lean and their difference is how round the back is.
@@ -434,6 +450,10 @@ function poseAt(table, t) {
     // Arms oppose their leg: the arm on the forward leg's side goes back.
     var armBack = { upper: mix(-table.armFwd, table.armBack), lower: -table.elbow }
     var armFwd = { upper: mix(table.armBack, -table.armFwd), lower: -table.elbow }
+    // The outward angle is signed by the SIDE, not by the phase: a positive
+    // roll on the +X arm and a negative one on the other take both away from
+    // the body.
+    function out(a, side) { return { upper: a.upper, lower: a.lower, out: table.armOut * side } }
 
     // Right leg forward means the right hip leads: a negative yaw brings the
     // +X side forward, so over the first phase the hip yaws from +sway to
@@ -446,8 +466,8 @@ function poseAt(table, t) {
     return {
         rightLeg: second ? back : fwd,
         leftLeg: second ? fwd : back,
-        rightArm: second ? armFwd : armBack,
-        leftArm: second ? armBack : armFwd,
+        rightArm: out(second ? armFwd : armBack, 1),
+        leftArm: out(second ? armBack : armFwd, -1),
         hip: [table.hipLean, yaw, 0],
         // The trunk group carries no pitch of its own any more: the tilt
         // lives in the two spine segments below it, whose angles add up to

--- a/plugins/clay_character3d/animation/gait.test.js
+++ b/plugins/clay_character3d/animation/gait.test.js
@@ -17,8 +17,10 @@ const G = K.load(__dirname, 'gait.js', [
     'FACTORS', 'FACTOR_NAMES', 'BASES', 'PRESETS', 'PRESET_NAMES',
     'neutral', 'compose', 'scaled', 'emotionFactors', 'canonicalEmotion',
     'buildFactors', 'presetFactors', 'presetKnown', 'derive', 'strideLength',
-    'speedFor', 'poseAt', 'easeInOutQuad', 'liftAt', 'ankleZ'
+    'speedFor', 'poseAt', 'easeInOutQuad', 'liftAt', 'ankleZ', 'spineFrom',
+    'BUILD'
 ])
+G.BUILD_SOFT = G.BUILD.soft
 
 const ok = K.ok, eq = K.eq, near = K.near, section = K.section
 const rad = Math.PI / 180
@@ -103,11 +105,19 @@ section('the planted foot does not slide: net slip is zero by construction')
 section('a factor lean bends at the waist, a base lean does not')
 {
     const w = G.derive('walk', { lean: 8 })
-    eq('walk: torso carries it', w.lean, 8)
-    eq('walk: hip counters it', w.waistLean, 8)
+    eq('walk: the trunk carries it', w.lean, 8)
+    eq('walk: it is all waist', w.waistLean, 8)
+    // What the legs end up doing: belly + hip is where the pelvis points, and
+    // under a factor lean that must be straight up.
+    near('walk: the legs stay planted', w.bellyLean + w.hipLean, 0, 1e-12)
     const r = G.derive('run', { lean: 8 })
-    eq('run: torso carries base plus factor', r.lean, 20)
-    eq('run: hip counters only the factor', r.waistLean, 8)
+    eq('run: the trunk carries base plus factor', r.lean, 20)
+    eq('run: only the factor is at the waist', r.waistLean, 8)
+    near('run: the legs tip with the base lean', r.bellyLean + r.hipLean, 12, 1e-12)
+    near('run neutral: the legs tip the whole 12',
+         G.derive('run', null).bellyLean + G.derive('run', null).hipLean, 12, 1e-12)
+    near('walk neutral: nothing tips at all',
+         G.derive('walk', null).bellyLean + G.derive('walk', null).hipLean, 0, 1e-12)
 }
 
 section('derive without factors, and with nonsense, is neutral')
@@ -336,8 +346,9 @@ section('poseAt replays the cycle the animation plays')
     near('torso counters the hip', p0.torso[1], -t.sway / 2, 1e-12)
     near('roll at t=0', p0.torso[2], -t.rock, 1e-12)
     near('roll at t=0.5', pHalf.torso[2], t.rock, 1e-12)
-    near('lean holds', pQ.torso[0], t.lean, 1e-12)
-    near('the hip counters the waist lean', pQ.hip[0], -t.waistLean, 1e-12)
+    near('the trunk group carries no pitch', pQ.torso[0], 0, 1e-12)
+    near('belly and chest add up to the lean', pQ.belly[0] + pQ.chest[0], t.lean, 1e-12)
+    near('the hip gives back the belly bend', pQ.hip[0], t.hipLean, 1e-12)
     near('head holds', pQ.head[0], t.headPitch, 1e-12)
     near('elbow holds', pQ.rightArm.lower, -t.elbow, 1e-12)
     // The easing is Qt's InOutQuad.
@@ -355,7 +366,92 @@ section('a neutral pose is the legacy key pose')
     eq('no lift', p.lift, 0)
     eq('level hip', JSON.stringify(p.hip), JSON.stringify([0, 0, 0]))
     eq('upright torso', JSON.stringify(p.torso), JSON.stringify([0, 0, 0]))
+    eq('straight belly', JSON.stringify(p.belly), JSON.stringify([0, 0, 0]))
+    eq('straight chest', JSON.stringify(p.chest), JSON.stringify([0, 0, 0]))
     eq('level head', JSON.stringify(p.head), JSON.stringify([0, 0, 0]))
+}
+
+// ------------------------------------------------------------------- the spine
+section('the trunk is two segments: the lean is shared, the curve is differential')
+{
+    // Whatever the split does, the head must end up where the single-box
+    // torso put it - the stride, the speed and every anchor above the waist
+    // are derived from that.
+    for (const f of [{ lean: 8 }, { lean: -6 }, { spineCurve: 20 }, { lean: 9, spineCurve: -14 }, {}]) {
+        const t = G.derive('walk', G.compose([f]))
+        near('walk ' + JSON.stringify(f) + ': belly + chest == lean',
+             t.bellyLean + t.chestLean, t.lean, 1e-9)
+        const r = G.derive('run', G.compose([f]))
+        near('run ' + JSON.stringify(f) + ': belly + chest == lean',
+             r.bellyLean + r.chestLean, r.lean, 1e-9)
+    }
+
+    const n = G.derive('walk', null)
+    eq('a neutral walk has a straight back', n.bellyLean, 0)
+    eq('a neutral walk has a straight chest', n.chestLean, 0)
+
+    // spineCurve alone is a pure curve: the back rounds, the head does not move.
+    const c = G.derive('walk', G.compose([{ spineCurve: 20 }]))
+    near('a pure curve does not tilt the trunk', c.bellyLean + c.chestLean, 0, 1e-9)
+    ok('a positive curve rounds the back forward', c.chestLean > 0 && c.bellyLean < 0)
+    const a = G.derive('walk', G.compose([{ spineCurve: -20 }]))
+    ok('a negative curve arches it and lifts the chest', a.chestLean < 0 && a.bellyLean > 0)
+
+    // A factor lean bends over the spine rather than tipping as one piece:
+    // even with no spineCurve asked for, the two segments differ.
+    const l = G.derive('walk', G.compose([{ lean: 10 }]))
+    ok('a factor lean curves on its own', l.chestLean - l.bellyLean > 4)
+    // A base lean does not curve at all: a sprinter is a straight line from
+    // the ankles, so the whole 12 degrees goes on the belly and the waist
+    // joint stays shut.
+    const run = G.derive('run', null)
+    near('a neutral run tips rigidly', run.bellyLean, 12, 1e-9)
+    near('a neutral run keeps the waist shut', run.chestLean, 0, 1e-9)
+    near('a neutral run tips the legs with it', run.hipLean, 0, 1e-9)
+}
+
+section('the moods that need a back have one')
+{
+    const n = G.derive('walk', null)
+    const back = (t) => t.chestLean - t.bellyLean   // how round the back is
+    for (const [name, f] of [['dejected', G.presetFactors('dejected')],
+                             ['elderly', G.presetFactors('elderly')],
+                             ['sneak', G.presetFactors('sneak')],
+                             ['soft build', G.BUILD_SOFT]]) {
+        if (!f) continue
+        ok(name + ' rounds the back', back(G.derive('walk', G.compose([f]))) > back(n) + 8)
+    }
+    for (const [name, f] of [['proud', G.presetFactors('proud')],
+                             ['cheerful', G.presetFactors('cheerful')],
+                             ['march', G.presetFactors('march')]]) {
+        ok(name + ' arches it', back(G.derive('walk', G.compose([f]))) < back(n) - 4)
+    }
+    const toddler = G.derive('walk', G.compose([G.presetFactors('toddler')]))
+    ok('a toddler stands belly-first', back(toddler) < 0 && toddler.lean < 0)
+    const heavy = G.derive('walk', G.compose([G.presetFactors('heavy')]))
+    ok('a heavy walker leans back over its weight', heavy.lean < 0)
+}
+
+section('the angry walk is short, hard steps with the arms held in')
+{
+    // The failure this pins: anger written as a BIGGER walk. It came out as a
+    // lope with the forearms flapping, because ground covered easily is the
+    // opposite of what anger looks like.
+    const n = G.derive('walk', null)
+    const angry = G.derive('walk', G.compose([G.emotionFactors('angry')]))
+    ok('angry takes shorter steps than a neutral walk', angry.hipFwd < n.hipFwd)
+    ok('angry takes them quicker', angry.cycleMs < n.cycleMs)
+    ok('angry stamps', angry.kneeLift > n.kneeLift)
+    // The fists ride in front of the hips because the elbow is bent, not
+    // because the whole swing was slid forward - that produced two arms held
+    // out in front that barely alternated.
+    ok('angry bends the elbows', angry.elbow > 30)
+    ok('angry still swings the upper arms past each other',
+       angry.armFwd > 10 && angry.armBack > 4)
+    ok('angry reaches less far back than a neutral walk', angry.armBack < n.armBack)
+    ok('angry hunches the shoulders over the head',
+       angry.chestLean - angry.bellyLean > 8)
+    ok('angry throws its weight side to side', angry.rock > n.rock)
 }
 
 process.exit(K.report('gait model'))

--- a/plugins/clay_character3d/animation/gait.test.js
+++ b/plugins/clay_character3d/animation/gait.test.js
@@ -203,6 +203,28 @@ section('emotions: the same vocabulary the face uses')
     ok('happy swings the arms further than angry', happy.armFwd + happy.armBack > angry.armFwd + angry.armBack)
 }
 
+section('armOut carries the upper arms off the ribs, and only that')
+{
+    const n = G.derive('walk', null)
+    eq('neutral holds them against the body', n.armOut, 0)
+    const f = G.derive('walk', G.compose([{ armOut: 14 }]))
+    eq('the factor arrives', f.armOut, 14)
+    near('and moves nothing else', f.armFwd, n.armFwd, 1e-12)
+    near('nor the reach behind', f.armBack, n.armBack, 1e-12)
+    eq('never adducts past the body', G.derive('walk', G.compose([{ armOut: -30 }])).armOut, 0)
+
+    // Signed by the side, not by the phase: both arms go OUT, and they stay
+    // out for the whole cycle.
+    for (const t of [0, 0.2, 0.5, 0.75]) {
+        const p = G.poseAt(f, t)
+        near('t=' + t + ': the right arm rolls +out', p.rightArm.out, 14, 1e-12)
+        near('t=' + t + ': the left arm rolls -out', p.leftArm.out, -14, 1e-12)
+    }
+    const p0 = G.poseAt(G.derive('walk', null), 0)
+    eq('a neutral walk keeps them in', p0.rightArm.out, 0)
+    eq('and on the other side too', p0.leftArm.out, 0)
+}
+
 section('armForward shifts the swing, keeps its amplitude')
 {
     const n = G.derive('walk', null)
@@ -365,6 +387,8 @@ section('a neutral pose is the legacy key pose')
     const p = G.poseAt(G.derive('walk', null), 0)
     eq('no lift', p.lift, 0)
     eq('level hip', JSON.stringify(p.hip), JSON.stringify([0, 0, 0]))
+    eq('arms against the body', p.rightArm.out + p.leftArm.out, 0)
+    eq('and not held out at all', p.rightArm.out, 0)
     eq('upright torso', JSON.stringify(p.torso), JSON.stringify([0, 0, 0]))
     eq('straight belly', JSON.stringify(p.belly), JSON.stringify([0, 0, 0]))
     eq('straight chest', JSON.stringify(p.chest), JSON.stringify([0, 0, 0]))
@@ -451,7 +475,12 @@ section('the angry walk is short, hard steps with the arms held in')
     ok('angry reaches less far back than a neutral walk', angry.armBack < n.armBack)
     ok('angry hunches the shoulders over the head',
        angry.chestLean - angry.bellyLean > 8)
-    ok('angry throws its weight side to side', angry.rock > n.rock)
+    ok('angry shifts its weight side to side', angry.rock > n.rock)
+    // ...but not much. Four degrees each way at this tempo is a waddle, and
+    // rolling side to side is what WEIGHT looks like, not what anger does.
+    ok('angry does not waddle', angry.rock <= G.derive('walk',
+       G.compose([G.presetFactors('heavy')])).rock / 2)
+    ok('angry carries the upper arms off the ribs', angry.armOut > 8)
 }
 
 process.exit(K.report('gait model'))

--- a/plugins/clay_character3d/bench/CrowdSandbox.qml
+++ b/plugins/clay_character3d/bench/CrowdSandbox.qml
@@ -28,12 +28,28 @@
 // those boxes rounder or smoother is close to free while having more of them
 // is not.
 //
-// A character is 21 boxes at Low, 43 at High and 20 at Minimal, measured here
-// at twenty characters: 420, 860 and 400 draw calls, for 10.68, 17.13 and
-// 10.07 ms of render time.
+// A character is 22 boxes at Low, 44 at High and 21 at Minimal: 440, 880 and
+// 420 draw calls at twenty characters.
 //
-// Those three numbers used to be 33, 53 and 20, and the gap between the first
-// and the last was the face - thirteen boxes carrying none of the silhouette,
+// WHAT THE WAIST JOINT COSTS (#227). Splitting the torso into a belly and a
+// chest is EXACTLY ONE DRAW CALL and 36 vertices per character, at every
+// detail tier. Measured against the build before it, same machine, same
+// session: at twenty characters 420 draws became 440 at Low and 860 became
+// 880 at High; at forty, 840 became 880 and 1720 became 1760. The trunk group
+// that holds the two segments draws nothing itself, and they are the same
+// material, shader and geometry type as the one box they replaced.
+//
+// In time that is about 0.02 ms per character, which is what this bench's own
+// fit (0.0178 ms per draw call) predicts. Medians of three runs at forty
+// characters: 5.30 -> 5.96 ms at Low, 8.14 -> 8.22 ms at High. The Low figure
+// matches the fit; the High one is inside the run-to-run spread, so treat the
+// fit as the number and the measurement as agreeing with it.
+//
+// Detail does not help with it. The tiers are about the face and the fingers;
+// the trunk is silhouette, and a character has one at every distance.
+//
+// The box counts used to be 33, 53 and 20, and the gap between the first and
+// the last was the face - thirteen boxes carrying none of the silhouette,
 // which is why Minimal deleted it. The face is drawn in a fragment shader now
 // and costs no draw calls at all, so it no longer appears in this table. Two
 // consequences worth knowing before tuning anything:

--- a/plugins/clay_character3d/bench/GaitSheetSandbox.qml
+++ b/plugins/clay_character3d/bench/GaitSheetSandbox.qml
@@ -25,8 +25,23 @@
 // of them looks wrong on the sheet it looks wrong at speed.
 //
 // yaw turns the figures: 90 is the classic side view walking screen-right,
-// 0 is head-on, 45 three-quarter. Factors beyond a preset go through the
-// shared Gait: --eval 'sheetGait.lean = 6'.
+// 0 is head-on, 180 from behind, 45 three-quarter. pitch lifts the CAMERA
+// instead - 0 is eye level, 90 straight down - so the same sheet can be read
+// from above, which is the only angle that shows sway and rock honestly.
+// Factors beyond a preset go through the shared Gait:
+// --eval 'sheetGait.lean = 6'.
+//
+// The four views worth checking a change against, as one loop:
+//
+//   for v in "front 0 0" "side 90 0" "back 180 0" "top 90 88"; do
+//     set -- $v
+//     clayrender plugins/clay_character3d/bench/GaitSheetSandbox.qml \
+//       --size 1800x520 --set 'preset="dejected"' \
+//       --set "yaw=$2" --set "pitch=$3" --wait-for 'ready' --out /tmp/sheet-$1.png
+//   done
+//
+// A silhouette that reads as walking from all four is a cycle; one that only
+// reads from the side is a side view.
 
 import QtQuick
 import QtQuick3D
@@ -60,8 +75,13 @@ Item {
     /*! Whether the build feeds the gait (Character.gaitFromBuild). */
     property bool fromBuild: true
 
-    /*! How the figures are turned: 90 is side-on walking screen-right. */
+    /*! How the figures are turned: 90 is side-on walking screen-right,
+        0 head-on, 180 from behind. */
     property real yaw: 90
+
+    /*! How far the camera is lifted, in degrees: 0 is eye level, 90 straight
+        down. The floor is dropped past 60, where it would cover the figures. */
+    property real pitch: 0
 
     /*! The shared gait; drive its factors with --eval for tuning. */
     readonly property Gait gait: sheetGait
@@ -109,6 +129,12 @@ Item {
         }
         const cycle = root.base === "run" ? c.runSpeed : c.walkSpeed
         s += " | speed " + cycle.toFixed(2)
+        // What the trunk is actually doing, which is the thing a sheet is read
+        // for and the one thing a factor list does not say outright.
+        const p = c.gaitPoseAt(root.base, 0)
+        s += "  | belly " + p.belly[0].toFixed(1) + " chest " + p.chest[0].toFixed(1)
+           + " back " + (p.chest[0] - p.belly[0]).toFixed(1)
+        s += "  | yaw " + root.yaw.toFixed(0) + " pitch " + root.pitch.toFixed(0)
         return s
     }
 
@@ -141,12 +167,17 @@ Item {
             brightness: 0.4
         }
 
-        // Head-on, orthographic: figures along X map linearly to the screen, so
-        // a frame label sits under its figure and the lift reads against the
-        // floor line without perspective in the way.
+        // Orthographic: figures along X map linearly to the screen, so a frame
+        // label sits under its figure and the lift reads against the floor
+        // line without perspective in the way. pitch swings the camera up over
+        // the row on the same arc, keeping the row centred whatever it is.
         OrthographicCamera {
             id: cam
-            position: Qt.vector3d(root._span * 0.5 - root._spacing * 0.5, root.bodyHeight * 0.5, 200)
+            readonly property real _r: Math.PI / 180 * root.pitch
+            position: Qt.vector3d(root._span * 0.5 - root._spacing * 0.5,
+                                  root.bodyHeight * 0.5 + 200 * Math.sin(cam._r),
+                                  200 * Math.cos(cam._r))
+            eulerRotation: Qt.vector3d(-root.pitch, 0, 0)
             horizontalMagnification: Math.max(0.01, v3d.width) / (root._span * 1.05)
             verticalMagnification: horizontalMagnification
             clipNear: 1
@@ -156,6 +187,8 @@ Item {
         // The floor: a slab whose top face is y = 0, so the feet stand on a
         // line and a bounce leaves it visibly.
         Box3D {
+            // From overhead it would be a lid over the whole sheet.
+            visible: root.pitch < 60
             position: Qt.vector3d(root._span * 0.5 - root._spacing * 0.5, -0.3, 0)
             width: root._span * 1.1
             height: 0.6
@@ -263,6 +296,8 @@ Item {
     Keys.onPressed: (e) => {
         if (e.key === Qt.Key_Right) root.yaw += 15
         else if (e.key === Qt.Key_Left) root.yaw -= 15
+        else if (e.key === Qt.Key_W) root.pitch = Math.min(90, root.pitch + 15)
+        else if (e.key === Qt.Key_S) root.pitch = Math.max(0, root.pitch - 15)
         else if (e.key === Qt.Key_Up) root.frames = Math.min(16, root.frames + 1)
         else if (e.key === Qt.Key_Down) root.frames = Math.max(2, root.frames - 1)
         else if (e.key === Qt.Key_B) root.base = root.base === "walk" ? "run" : "walk"
@@ -285,6 +320,7 @@ Item {
         font.family: _header.font.family
         font.pixelSize: 11
         color: "#6b6b72"
-        text: "left/right turn   up/down frames   b walk/run   p next preset   1/2/3/0 emotion"
+        text: "left/right turn   w/s camera up/down   up/down frames   b walk/run"
+            + "   p next preset   1/2/3/0 emotion"
     }
 }

--- a/plugins/clay_character3d/tests/qml/tst_gait.qml
+++ b/plugins/clay_character3d/tests/qml/tst_gait.qml
@@ -46,6 +46,8 @@ Item {
         property StubLimb rightArm: StubLimb {}
         property StubLimb leftArm: StubLimb {}
         property Joint torso: Joint {}
+        property Joint belly: Joint {}
+        property Joint chest: Joint {}
         property Joint hip: Joint {}
         property StubHead head: StubHead {}
         function reset() {
@@ -53,6 +55,8 @@ Item {
                 for (const j of [l.upperLeg, l.lowerLeg, l.foot, l.upperArm, l.lowerArm, l.hand])
                     j.eulerRotation = Qt.vector3d(0, 0, 0)
             torso.eulerRotation = Qt.vector3d(0, 0, 0)
+            belly.eulerRotation = Qt.vector3d(0, 0, 0)
+            chest.eulerRotation = Qt.vector3d(0, 0, 0)
             hip.eulerRotation = Qt.vector3d(0, 0, 0)
             head.poseEuler = Qt.vector3d(0, 0, 0)
         }
@@ -115,9 +119,12 @@ Item {
             tryVerify(() => body.rightArm.upperArm.moved(), 1000)
             tryVerify(() => body.leftArm.upperArm.moved(), 1000)
             tryVerify(() => body.rightArm.lowerArm.moved(), 1000)
-            // A neutral walk holds the torso, hip and head level throughout.
+            // A neutral walk holds the trunk, the two spine segments, the hip
+            // and the head level throughout.
             wait(450)
             verify(!body.torso.moved())
+            verify(!body.belly.moved())
+            verify(!body.chest.moved())
             verify(!body.hip.moved())
             compare(body.head.poseEuler, Qt.vector3d(0, 0, 0))
             compare(walk.lift, 0)
@@ -125,7 +132,11 @@ Item {
 
         function test_run_leans_and_bends_the_elbows() {
             run.start()
-            tryVerify(() => Math.abs(body.torso.eulerRotation.x - 12) < 0.01, 1000)
+            // The 12-degree run lean is shared over the waist joint, so it is
+            // belly plus chest that comes to 12 - the group itself stays level.
+            tryVerify(() => Math.abs(body.belly.eulerRotation.x
+                                     + body.chest.eulerRotation.x - 12) < 0.01, 1000)
+            verify(Math.abs(body.torso.eulerRotation.x) < 0.01)
             tryVerify(() => Math.abs(body.rightArm.lowerArm.eulerRotation.x + 70) < 0.01, 1000)
         }
 
@@ -144,12 +155,29 @@ Item {
         function test_posture_factors_reach_the_joints() {
             body.gaitFactors = { lean: 8, headPitch: 15, sway: 6, rock: 4 }
             walk.start()
-            tryVerify(() => Math.abs(body.torso.eulerRotation.x - 8) < 0.05, 1000)
+            // The lean arrives as two angles that add up to it.
+            tryVerify(() => Math.abs(body.belly.eulerRotation.x
+                                     + body.chest.eulerRotation.x - 8) < 0.05, 1000)
             tryVerify(() => Math.abs(body.head.poseEuler.x - 15) < 0.05, 1000)
-            // The hip counters the waist lean so the legs stay planted.
-            tryVerify(() => Math.abs(body.hip.eulerRotation.x + 8) < 0.05, 1000)
+            // The hip gives back the belly's share, so the legs stay planted.
+            tryVerify(() => Math.abs(body.belly.eulerRotation.x
+                                     + body.hip.eulerRotation.x) < 0.05, 1000)
             tryVerify(() => Math.abs(Math.abs(body.hip.eulerRotation.y) - 6) < 0.05, 1500)
             tryVerify(() => Math.abs(Math.abs(body.torso.eulerRotation.z) - 4) < 0.05, 1500)
+        }
+
+        // The one claim the split has to keep: a rounded back is a difference
+        // between the two segments, and it does not move the head.
+        function test_a_spine_curve_rounds_the_back_without_tipping_it() {
+            body.gaitFactors = { spineCurve: 20 }
+            walk.start()
+            tryVerify(() => body.chest.eulerRotation.x > 5, 1000)
+            verify(body.belly.eulerRotation.x < -5)
+            verify(Math.abs(body.belly.eulerRotation.x
+                            + body.chest.eulerRotation.x) < 0.05)
+            // And the legs are untouched: nothing was asked to lean.
+            verify(Math.abs(body.belly.eulerRotation.x
+                            + body.hip.eulerRotation.x) < 0.05)
         }
 
         function test_tempo_and_stride_change_the_speed() {
@@ -195,6 +223,8 @@ Item {
             fuzzyCompare(walk.cycleMs, 800 / (0.72 * 1.2), 1e-6)
             compare(walk.table.lean, 8)
             verify(walk.table.kneeLift < 45)
+            // and an elderly walk rounds the back rather than tipping it
+            verify(walk.table.chestLean - walk.table.bellyLean > 8)
         }
     }
 }

--- a/plugins/clay_character3d/tests/qml/tst_gait.qml
+++ b/plugins/clay_character3d/tests/qml/tst_gait.qml
@@ -126,6 +126,8 @@ Item {
             verify(!body.belly.moved())
             verify(!body.chest.moved())
             verify(!body.hip.moved())
+            compare(body.rightArm.upperArm.eulerRotation.z, 0)
+            compare(body.leftArm.upperArm.eulerRotation.z, 0)
             compare(body.head.poseEuler, Qt.vector3d(0, 0, 0))
             compare(walk.lift, 0)
         }
@@ -178,6 +180,21 @@ Item {
             // And the legs are untouched: nothing was asked to lean.
             verify(Math.abs(body.belly.eulerRotation.x
                             + body.hip.eulerRotation.x) < 0.05)
+        }
+
+        // The channel that did not exist before: a Vector3dAnimation writing a
+        // z that nothing reads would be silent, so this asserts the roll lands
+        // on both upper arms, with opposite signs, and holds through the cycle.
+        function test_armOut_rolls_both_upper_arms_off_the_ribs() {
+            body.gaitFactors = { armOut: 14 }
+            compare(walk.table.armOut, 14)
+            walk.start()
+            tryVerify(() => Math.abs(body.rightArm.upperArm.eulerRotation.z - 14) < 0.05, 1000)
+            verify(Math.abs(body.leftArm.upperArm.eulerRotation.z + 14) < 0.05)
+            // still there half a cycle later - it is a carriage, not a swing
+            wait(450)
+            verify(Math.abs(body.rightArm.upperArm.eulerRotation.z - 14) < 0.05)
+            verify(Math.abs(body.leftArm.upperArm.eulerRotation.z + 14) < 0.05)
         }
 
         function test_tempo_and_stride_change_the_speed() {

--- a/plugins/clay_character3d/tests/qml_head/tst_torso.qml
+++ b/plugins/clay_character3d/tests/qml_head/tst_torso.qml
@@ -1,0 +1,236 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+//
+// The two-segment torso: a belly and a chest on a waist joint (#227).
+//
+// This needs the BUILT module - the segments are Box3D, whose geometry is C++
+// in Canvas3D - so it is one of the halves Windows has to skip (#192).
+//
+// The claim it exists to pin is the one a screenshot can only suggest: at the
+// default bellyRatio, bellyBulge, chestSwell and waistPinch the two boxes
+// trace EXACTLY the tapered box the torso used to be - same shoulders, same
+// waist, same depth, same total height, and the two of them meeting on the
+// line between shoulder and waist rather than near it. Everything above the
+// trunk (the shoulder joints, the head) has to come out at the same place
+// too, because the arm solver, the gesture layer and the camera director all
+// start from those anchors.
+
+import QtQuick
+import QtTest
+import Clayground.Character3D
+
+Item {
+    id: root
+    width: 50; height: 50
+
+    TestCase {
+        id: tc
+        name: "Torso"
+        when: windowShown
+
+        // Plain numbers rather than the defaults, so a changed default cannot
+        // make an assertion vacuous.
+        Character {
+            id: c
+            shoulderWidth: 4.0
+            waistWidth: 3.0
+            torsoHeight: 2.5
+            torsoDepth: 1.2
+            hipHeight: 1.0
+            hipWidth: 3.0
+            legHeight: 5.0
+            footHeight: 0.4
+            neckHeight: 0.5
+        }
+
+        function init() {
+            // IdleAnim zeroes every joint over its first 200 ms; a test that
+            // writes a joint before that has finished is writing under it.
+            wait(300)
+            c.bellyRatio = 0.45
+            c.bellyBulge = 1.0
+            c.chestSwell = 1.0
+            c.waistPinch = 0.0
+            c.gait.lean = 0
+            c.gait.spineCurve = 0
+            c.belly.eulerRotation = Qt.vector3d(0, 0, 0)
+            c.chest.eulerRotation = Qt.vector3d(0, 0, 0)
+            c.torso.eulerRotation = Qt.vector3d(0, 0, 0)
+            c.hip.eulerRotation = Qt.vector3d(0, 0, 0)
+        }
+
+        // --- the silhouette is the one the single box drew ----------------------
+
+        function test_the_two_segments_add_up_to_the_torso() {
+            fuzzyCompare(c.belly.height + c.chest.height, c.torsoHeight, 1e-6)
+            fuzzyCompare(c.belly.height, c.torsoHeight * 0.45, 1e-6)
+            compare(c.chest.width, c.shoulderWidth)
+        }
+
+        // Bottom of the belly is the waist, top of the chest is the shoulders,
+        // and the joint between them sits on the straight line between the two
+        // - which is what makes the pair trace the old trapezoid rather than
+        // merely resemble it.
+        function test_the_outline_is_the_old_trapezoid() {
+            // The belly is measured at its bottom (the hip) and scaled at its
+            // top (the joint); the chest the other way round.
+            fuzzyCompare(c.belly.width, c.waistWidth, 1e-6)
+            const joint = c.waistWidth + (c.shoulderWidth - c.waistWidth) * 0.45
+            fuzzyCompare(c.belly.width * c.belly.faceScale.x, joint, 1e-6)
+            // and the chest's bottom is the belly's top, so there is no step
+            fuzzyCompare(c.chest.width * c.chest.faceScale.x, joint, 1e-6)
+        }
+
+        function test_the_depth_is_the_torso_depth_all_the_way_up() {
+            fuzzyCompare(c.belly.depth, c.torsoDepth, 1e-6)
+            fuzzyCompare(c.belly.depth * c.belly.faceScale.y, c.torsoDepth, 1e-6)
+            fuzzyCompare(c.chest.depth, c.torsoDepth, 1e-6)
+            fuzzyCompare(c.chest.depth * c.chest.faceScale.y, c.torsoDepth, 1e-6)
+        }
+
+        // The anchors the rest of the framework aims from. They used to be
+        // sums over the single torso; they are sums over the trunk chain now
+        // and have to answer with the same numbers.
+        function test_the_anchors_did_not_move() {
+            const trunkBottom = c.legHeight + c.footHeight + c.hipHeight
+            fuzzyCompare(c.rightShoulderPos.y, trunkBottom + c.torsoHeight, 1e-6)
+            fuzzyCompare(c.rightShoulderPos.x, c.shoulderWidth * 0.5, 1e-6)
+            fuzzyCompare(c.rightShoulderPos.z, 0, 1e-6)
+            fuzzyCompare(c.leftShoulderPos.x, -c.shoulderWidth * 0.5, 1e-6)
+            fuzzyCompare(c.headPos.y, trunkBottom + c.torsoHeight + c.neckHeight, 1e-6)
+            fuzzyCompare(c.headPos.z, 0, 1e-6)
+        }
+
+        // --- what the split buys ------------------------------------------------
+
+        function test_a_bulging_belly_hangs_over_the_hip_and_leaves_the_rest_alone() {
+            const joint = c.waistWidth + (c.shoulderWidth - c.waistWidth) * 0.45
+            c.bellyBulge = 1.4
+            // It is widest and deepest at the BOTTOM, where the hip is, so it
+            // overhangs the belt instead of tapering into it.
+            verify(c.belly.depth > c.torsoDepth)
+            verify(c.belly.width > c.waistWidth)
+            // Its top is still the plain joint section, so the ribcage above
+            // is not dragged wider with it.
+            fuzzyCompare(c.belly.width * c.belly.faceScale.x, joint, 1e-6)
+            fuzzyCompare(c.belly.depth * c.belly.faceScale.y, c.torsoDepth, 1e-6)
+            // and it is in front of the body rather than around it
+            verify(c.belly.basePos.z > 0)
+            // The chest keeps its own section and still meets the joint.
+            fuzzyCompare(c.chest.depth, c.torsoDepth, 1e-6)
+            fuzzyCompare(c.chest.width * c.chest.faceScale.x, joint, 1e-6)
+            fuzzyCompare(c.chest.depth * c.chest.faceScale.y, c.torsoDepth, 1e-6)
+            // and nothing above or below the waist has moved
+            fuzzyCompare(c.headPos.z, 0, 1e-6)
+            fuzzyCompare(c.rightShoulderPos.z, 0, 1e-6)
+            fuzzyCompare(c.hip.basePos.z + c.belly.basePos.z, 0, 1e-6)
+        }
+
+        function test_a_swelled_chest_is_depth_and_not_shoulders() {
+            c.chestSwell = 1.25
+            verify(c.chest.depth > c.torsoDepth)
+            compare(c.chest.width, c.shoulderWidth)
+            fuzzyCompare(c.belly.depth, c.torsoDepth, 1e-6)
+            fuzzyCompare(c.rightShoulderPos.x, c.shoulderWidth * 0.5, 1e-6)
+        }
+
+        // The one shape a single tapered box could not make: narrow in the
+        // middle, wider at both ends.
+        function test_a_pinch_narrows_the_joint_and_nothing_else() {
+            const joint = c.waistWidth + (c.shoulderWidth - c.waistWidth) * 0.45
+            const shoulders = c.chest.width
+            c.waistPinch = 0.2
+            verify(c.belly.width * c.belly.faceScale.x < joint)
+            fuzzyCompare(c.chest.width * c.chest.faceScale.x,
+                         c.belly.width * c.belly.faceScale.x, 1e-6)
+            compare(c.chest.width, shoulders)
+            fuzzyCompare(c.belly.width, c.waistWidth, 1e-6)
+        }
+
+        function test_the_ratio_moves_the_joint() {
+            c.bellyRatio = 0.7
+            fuzzyCompare(c.belly.height, c.torsoHeight * 0.7, 1e-6)
+            fuzzyCompare(c.belly.height + c.chest.height, c.torsoHeight, 1e-6)
+            // The joint is further up, so it is wider - still on the line.
+            fuzzyCompare(c.belly.width * c.belly.faceScale.x,
+                         c.waistWidth + (c.shoulderWidth - c.waistWidth) * 0.7, 1e-6)
+        }
+
+        // --- the joint bends ----------------------------------------------------
+
+        // What makes a waist joint a joint: everything above it hangs off the
+        // chest and everything below off the belly, so bending either carries
+        // the right half of the body. Asserted as the parent chain rather than
+        // as scene positions, because a node outside a View3D never syncs one -
+        // scenePosition answers with whatever it held at construction, which is
+        // a test that passes for the wrong reason as easily as it fails.
+        function test_the_chest_carries_the_head_and_the_arms() {
+            compare(c.chest.parent, c.belly)
+            compare(c.head.parent, c.chest)
+            compare(c.rightArm.parent, c.chest)
+            compare(c.leftArm.parent, c.chest)
+        }
+
+        function test_the_belly_carries_the_hip_and_the_legs() {
+            compare(c.belly.parent, c.torso)
+            compare(c.hip.parent, c.belly)
+            compare(c.rightLeg.parent, c.hip)
+            compare(c.leftLeg.parent, c.hip)
+        }
+
+        // --- a gait pose lands on the segments ----------------------------------
+
+        function test_applyGaitPose_puts_the_lean_in_the_spine() {
+            c.gait.lean = 10
+            c.gait.spineCurve = 18
+            c.applyGaitPose("walk", 0.25)
+            fuzzyCompare(c.belly.eulerRotation.x + c.chest.eulerRotation.x, 10, 0.01)
+            verify(c.chest.eulerRotation.x - c.belly.eulerRotation.x > 15)
+            compare(c.torso.eulerRotation.x, 0)
+            // the legs stay planted: the hip gives the belly's bend back
+            fuzzyCompare(c.belly.eulerRotation.x + c.hip.eulerRotation.x, 0, 0.01)
+        }
+    }
+
+    // --- the build reaches the trunk -------------------------------------------
+
+    TestCase {
+        name: "TorsoBuild"
+        when: windowShown
+
+        ParametricCharacter { id: p }
+
+        function init() {
+            p.mass = 0.5
+            p.muscle = 0.5
+            p.femininity = 0.5
+        }
+
+        function test_the_defaults_change_nothing() {
+            fuzzyCompare(p.bellyBulge, 1.0, 1e-9)
+            fuzzyCompare(p.chestSwell, 1.0, 1e-9)
+            fuzzyCompare(p.waistPinch, 0.0, 1e-9)
+        }
+
+        function test_mass_is_the_belly_and_muscle_is_the_chest() {
+            p.mass = 1.0
+            verify(p.bellyBulge > 1.1)
+            fuzzyCompare(p.chestSwell, 1.0, 1e-9)
+            p.mass = 0.0
+            verify(p.bellyBulge < 1.0)
+            p.mass = 0.5
+
+            p.muscle = 1.0
+            verify(p.chestSwell > 1.1)
+            fuzzyCompare(p.bellyBulge, 1.0, 1e-9)
+            p.muscle = 0.0
+            verify(p.chestSwell < 1.0)
+        }
+
+        function test_a_waist_comes_from_muscle_and_goes_with_mass() {
+            p.muscle = 1.0
+            verify(p.waistPinch > 0.05)
+            p.mass = 1.0
+            fuzzyCompare(p.waistPinch, 0.0, 1e-9)
+        }
+    }
+}


### PR DESCRIPTION
`Character.torso` is now a group that draws nothing, holding a `belly` and a
`chest` on a waist joint; the trunk's pitch lives in those two and their sum is
still `lean`, so the shoulders, the head and every anchor above them come out
exactly where the single tapered box put them.

- two new gait factors. `spineCurve` is the angle between the two segments -
  differential, so it rounds or arches the back without moving the head. A
  factor `lean` brings some curve with it on its own; a base lean (a run's 12
  degrees) stays a rigid tip, because a sprinter is a straight line from the
  ankles. `armOut` carries the upper arms off the ribs - the cycle swung them
  fore and aft and nothing else, so every gait had the arms glued to the sides
  and an angry walk could not be told from a hurried one head-on
- `dejected`, `elderly`, `sneak` and `soft` round the back, `proud`,
  `cheerful`, `march`, `toddler` and `heavy` arch it. `heavy` now leans *back*
  over the weight it carries; `elderly` was pulled further from `dejected`
  (shorter, lower steps) because on a sheet the two were the same slouch
- `furious` was rewritten: short hard quick steps, knees stamping, shoulders
  hunched over a forward head, upper arms carried 13 degrees off the ribs and
  the fists before the chest by a bent elbow. The old one strode further than a
  neutral walk with the arms slid 22 degrees forward, which read as a lope with
  the forearms flapping
- `ParametricCharacter` maps `mass` to `bellyBulge` and `muscle` to
  `chestSwell`, both exactly neutral at 0.5; `muscle` and `femininity` also
  draw a `waistPinch` - narrow in the middle, wider at both ends, which one
  tapered box could not make
- `GaitCycleAnim`, `IdleAnim`, `UseAnim`, `FightAnim`, `TalkGestureAnim` and
  `GestureAnim`'s talking beats all bend at the waist now. The talk beats' lean
  used to pitch the character's own node, feet included
- `GaitSheetSandbox` takes a `pitch`, so the same sheet can be read from
  overhead as well as from the side, front and back

Verified:
- `ctest --preset default` -> exit 0, 100% tests passed out of 52
- `node plugins/clay_character3d/animation/gait.test.js` -> exit 0, 235 passed, 0 failed
- `qml_character3d_head_qml` (new `tst_torso.qml` + `tst_headpose.qml`) -> 29 passed, 0 failed. This is the "renders today's silhouette" box: the belly's bottom is `waistWidth` by `torsoDepth`, its top is on the line between waist and shoulders, the chest's bottom is that same joint section, and `rightShoulderPos`/`leftShoulderPos`/`headPos` are unchanged to 1e-6
- the "zero effect at the defaults" box, same suite: `bellyBulge`, `chestSwell` and `waistPinch` are 1, 1 and 0 at `mass`/`muscle`/`femininity` 0.5
- pixel diff of the default gait sheet against a build of `ea65251`: the outline is identical, 0.35% of pixels differ side-on and 1.84% head-on, and every one of them is the seam line at the new joint
- crowd bench against the same reference build: 420 -> 440 draw calls at Low and 860 -> 880 at High for 20 characters, 840 -> 880 and 1720 -> 1760 for 40. Exactly one draw call and 36 vertices per character, written into `bench/CrowdSandbox.qml`
- cycle sheets rendered for all ten presets from side, front and back, plus overhead, run, and eight build corners, and read against the Disney/Williams criteria
- `17 files changed, 1166 insertions(+), 130 deletions(-)`

Not verified: Windows (`qml_character3d_head_qml` is one of the suites that
needs the built module and cannot run there, #192); the render-time half of the
crowd number at the High tier is inside this machine's run-to-run spread, so the
draw-call count is the claim and the milliseconds only agree with it.

<details><summary>Cycle-sheet review, the two angry walks that did not work, and what I left alone</summary>

**How the sheets were read.** `bench/GaitSheetSandbox.qml` freezes eight
figures at successive phases of one cycle. Every preset was rendered side
(`yaw=90`), head-on (`yaw=0`) and from behind (`yaw=180`), and `furious` and
`neutral` also from overhead (`pitch=86`, the new parameter). Two reviewers
went over them against *The Illusion of Life* and *The Animator's Survival
Kit*; the fixes below came out of that.

**`furious` took three attempts.** The first replacement carried the whole arm
swing forward (`armForward: 22`, kept from the old version) with `armSwing`
down to 0.7 - both upper arms then sat ahead of the body at once and barely
alternated, which is a sleepwalker from every angle and showed on the head-on
sheet before it showed in motion. The second folded the elbow to 80 instead,
which put both forearms out horizontally: the same silhouette by another route.
What works is a normal swing with a hard bend and a small forward bias
(`armSwing: 1.0, elbow: 55, armForward: 8`) - the upper arms still pass each
other, and 65 degrees of elbow carries the fists from in front of the hip to in
front of the chest and back. All three are written up in `gait.js` so the next
person does not repeat them.

`armOut` came out of watching it move rather than off a sheet: with the upper
arms against the ribs the whole arm is a stub head-on, whatever the forearm is
doing. Thirteen degrees of it is the difference between a body ready to hit
something and one in a hurry. `rock` went back to 2 in the same pass - four
degrees each way at `tempo: 1.22` reads as a waddle, and side-to-side weight is
the heavy cue, not the angry one.

**The run's kink.** The first version shared a base lean between the segments
like a factor lean, which put a 7-degree fold in the middle of every runner's
back. A base lean now goes on the belly whole.

**Also changed from the sheets:** `cheerful` bounced 0.04, which was invisible
between contact and passing - now 0.075 with more knee lift and chin. `sad`
hangs the head further and swings the arms less. `elderly` reads as age rather
than as sadness now: `stride` 0.72 -> 0.60, `kneeLift` 0.6 -> 0.45.

**Left alone, and commented on the issue** (#227): there is no neck geometry,
so a head floats over the shoulders - pre-existing and pixel-identical to the
reference build, but a rounded chest makes it easier to see. `sneak` and
`heavy` want a crouch the gait table has no way to express. `maturity: 0` reads
as a small adult and `mass: 1` with `muscle: 1` is a slab, both from
`_widthMultiplier`/`_headsTall` in `ParametricCharacter`, untouched here.

**Why the belly is measured at its bottom.** The first version scaled the
belly's bottom face and grew the box at the top, which made a bulge that sat
under the ribs and tapered into the pelvis - a barrel, not a gut. It is the
other way round now: the box is measured where it meets the hip and its top
face is scaled to the joint, so `mass` overhangs the belt. Its extra depth goes
a third forward, and the chest and the hip take that offset straight back out,
so the head and the legs stay on the trunk's own axis however far it bulges.

**The seam.** Two coplanar boxes each draw their own face border, so a straight
waist has one line across it that the single box did not. Suppressing it with
`edgeMask` is not possible cleanly: the bits do not partition (`box3d_edges.glsl`
says so in its own comment), and masking the joint's ring also removed vertical
corner lines. It reads as a shirt hem and the outline is unaffected, so it
stays.

</details>

Closes #227
