### PR TITLE
ClayHttpClient supports basic auth and API keys

### DIFF
--- a/docs/docs/plugins/network.md
+++ b/docs/docs/plugins/network.md
@@ -194,14 +194,35 @@ ClayHttpClient {
 
 ### Authentication Options
 
+Three schemes, each configured by its own properties:
+
 ```qml
-// Direct token
+// Bearer token -> "Authorization: Bearer <token>"
+bearerToken: "your-token-here"
+
+// HTTP basic -> "Authorization: Basic <base64(user:password)>"
+basicAuthUser: "alice"
+basicAuthPassword: "s3cret"
+
+// API key -> a header of its own, "X-API-Key" unless renamed
+apiKey: "abc123"
+apiKeyHeader: "X-API-Key"
+```
+
+`bearerToken` takes precedence over `basicAuthUser`/`basicAuthPassword` — a
+request carries one `Authorization` header. `apiKey` is independent and can
+accompany either.
+
+Every credential value can be given literally or read from somewhere else:
+
+```qml
+// Direct value
 bearerToken: "your-token-here"
 
 // From environment variable
-bearerToken: "env:API_TOKEN"
+bearerToken: "env.API_TOKEN"
 
-// From file
+// From file (contents are trimmed)
 bearerToken: "file:///path/to/token.txt"
 ```
 

--- a/plugins/clay_network/ClayHttpClient.qml
+++ b/plugins/clay_network/ClayHttpClient.qml
@@ -6,8 +6,9 @@
     \brief Configurable HTTP client with automatic API method generation.
 
     ClayHttpClient provides a declarative way to define REST API endpoints
-    and generates callable methods automatically. It supports Bearer token
-    authentication and handles both GET and POST requests.
+    and generates callable methods automatically. It supports Bearer token,
+    HTTP basic and API key authentication and handles both GET and POST
+    requests.
 
     Example usage:
     \qml
@@ -60,6 +61,29 @@
     \brief Bearer token for authentication.
 
     If set, requests include an Authorization header with this token.
+    Takes precedence over basicAuthUser.
+
+    \qmlproperty string ClayHttpClient::basicAuthUser
+    \brief User name for HTTP basic authentication.
+
+    If set and bearerToken is empty, requests include an
+    "Authorization: Basic <base64(user:password)>" header.
+
+    \qmlproperty string ClayHttpClient::basicAuthPassword
+    \brief Password for HTTP basic authentication.
+
+    \qmlproperty string ClayHttpClient::apiKey
+    \brief API key sent in its own header.
+
+    If set, requests include the header named by apiKeyHeader with this
+    value. An API key can be combined with bearerToken or basic credentials.
+
+    \qmlproperty string ClayHttpClient::apiKeyHeader
+    \brief Name of the header carrying apiKey, "X-API-Key" by default.
+
+    Every credential value - bearerToken, basicAuthUser, basicAuthPassword
+    and apiKey - can be given literally, as "env.<VARIABLE>" to read it from
+    an environment variable, or as "file://<path>" to read it from a file.
 
     \qmlsignal ClayHttpClient::reply(int requestId, int returnCode, string text)
     \brief Emitted when a request completes successfully.
@@ -86,6 +110,10 @@ Item {
     property var endpoints: ({})
     property alias api: _apiConstructor.api
     property string bearerToken: ""
+    property string basicAuthUser: ""
+    property string basicAuthPassword: ""
+    property string apiKeyHeader: "X-API-Key"
+    property string apiKey: ""
 
     signal reply(int requestId, int returnCode, string text);
     signal error(int requestId, int returnCode, string text);
@@ -114,7 +142,6 @@ Item {
         // (Re-)Generates the API object based on the service config
         function updateServiceAccess() {
             api = {};
-            const authString = _formAuthString(_clayHttpClient.bearerToken);
 
             for (let endpoint in _clayHttpClient.endpoints) {
                 const parts = _clayHttpClient.endpoints[endpoint].split(' ');
@@ -128,14 +155,33 @@ Item {
                         const args = Array.prototype.slice.call(arguments);
                         const url = _constructUrl(_clayHttpClient.baseUrl, endpointUrl, args);
                         const json = jsonName !== "" && args.length ? args[args.length - 1] : "";
-                        return _handleRequestMethod(httpMethod, url, json, authString);
+                        // Credentials are read per call, not captured here:
+                        // they are commonly assigned after the endpoints, and
+                        // a captured copy would then be the empty one.
+                        return _handleRequestMethod(httpMethod, url, json,
+                                                    _formAuthString(), _formHeaders());
                     };
                 })(endpointUrl, httpMethod, jsonName);
             }
         }
 
-        function _formAuthString(bearerToken) {
-            return bearerToken !== "" ? `Bearer ${bearerToken}` : "";
+        // Bearer wins over basic when both are configured - a request carries
+        // one Authorization header.
+        function _formAuthString() {
+            if (_clayHttpClient.bearerToken !== "")
+                return `Bearer ${_clayHttpClient.bearerToken}`;
+            if (_clayHttpClient.basicAuthUser !== "")
+                return `Basic ${_clayHttpClient.basicAuthUser} ${_clayHttpClient.basicAuthPassword}`;
+            return "";
+        }
+
+        // An API key travels in its own header, so it can accompany a bearer
+        // token or basic credentials instead of replacing them.
+        function _formHeaders() {
+            let headers = {};
+            if (_clayHttpClient.apiKey !== "" && _clayHttpClient.apiKeyHeader !== "")
+                headers[_clayHttpClient.apiKeyHeader] = _clayHttpClient.apiKey;
+            return headers;
         }
 
         function _constructUrl(baseUrl, endpointUrl, args) {
@@ -144,15 +190,15 @@ Item {
             return url;
         }
 
-        function _handleRequestMethod(httpMethod, url, json, authString) {
+        function _handleRequestMethod(httpMethod, url, json, authString, headers) {
             switch (httpMethod) {
                 case "GET":
-                    return _webAccess.get(url, authString);
+                    return _webAccess.get(url, authString, headers);
                 case "POST":
                     // Convert JSON object to string if necessary
                     if (typeof json == "object" && json !== null && !Array.isArray(json))
                         json = JSON.stringify(json);
-                    return _webAccess.post(url, json, authString);
+                    return _webAccess.post(url, json, authString, headers);
             }
         }
     }

--- a/plugins/clay_network/README.md
+++ b/plugins/clay_network/README.md
@@ -216,8 +216,29 @@ ClayHttpClient {
 
 ### Authentication Options
 
+Three schemes, each configured by its own properties:
+
 ```qml
-bearerToken: "your-token-here"          // Direct token
-bearerToken: "env:API_TOKEN"            // From environment variable
-bearerToken: "file:///path/to/token.txt" // From file
+// Bearer token -> "Authorization: Bearer <token>"
+bearerToken: "your-token-here"
+
+// HTTP basic -> "Authorization: Basic <base64(user:password)>"
+basicAuthUser: "alice"
+basicAuthPassword: "s3cret"
+
+// API key -> a header of its own, "X-API-Key" unless renamed
+apiKey: "abc123"
+apiKeyHeader: "X-API-Key"
+```
+
+`bearerToken` takes precedence over `basicAuthUser`/`basicAuthPassword` — a
+request carries one `Authorization` header. `apiKey` is independent and can
+accompany either.
+
+Every credential value can be given literally or read from somewhere else:
+
+```qml
+bearerToken: "your-token-here"           // Direct value
+bearerToken: "env.API_TOKEN"             // From environment variable
+bearerToken: "file:///path/to/token.txt" // From file (trimmed)
 ```

--- a/plugins/clay_network/clay_network.qdoc
+++ b/plugins/clay_network/clay_network.qdoc
@@ -146,8 +146,9 @@
     \brief Configurable HTTP client with automatic API method generation.
 
     ClayHttpClient provides a declarative way to define REST API endpoints
-    and generates callable methods automatically. It supports Bearer token
-    authentication and handles both GET and POST requests.
+    and generates callable methods automatically. It supports Bearer token,
+    HTTP basic and API key authentication and handles both GET and POST
+    requests.
 
     Example usage:
     \qml
@@ -190,7 +191,22 @@
     Generated API methods object.
 
     \qmlproperty string ClayHttpClient::bearerToken
-    Bearer token for authentication.
+    Bearer token for authentication. Takes precedence over basicAuthUser.
+
+    \qmlproperty string ClayHttpClient::basicAuthUser
+    User name for HTTP basic authentication.
+
+    \qmlproperty string ClayHttpClient::basicAuthPassword
+    Password for HTTP basic authentication.
+
+    \qmlproperty string ClayHttpClient::apiKey
+    API key, sent in its own header and combinable with the other schemes.
+
+    \qmlproperty string ClayHttpClient::apiKeyHeader
+    Name of the header carrying apiKey, "X-API-Key" by default.
+
+    Every credential value can be given literally, as "env.<VARIABLE>" or
+    as "file://<path>".
 
     \section1 Signals
 

--- a/plugins/clay_network/claywebaccess.cpp
+++ b/plugins/clay_network/claywebaccess.cpp
@@ -14,20 +14,25 @@ ClayWebAccess::ClayWebAccess(QObject* parent)
             this, &ClayWebAccess::onFinished);
 }
 
-int ClayWebAccess::get(const QString &url, const QString& auth)
+int ClayWebAccess::get(const QString &url,
+                       const QString& auth,
+                       const QVariantMap& headers)
 {
     return sendRequest(QNetworkAccessManager::GetOperation,
                        url,
-                       auth);
+                       auth,
+                       headers);
 }
 
 int ClayWebAccess::post(const QString &url,
                         const QString& json,
-                        const QString& auth)
+                        const QString& auth,
+                        const QVariantMap& headers)
 {
     return sendRequest(QNetworkAccessManager::PostOperation,
                        url,
                        auth,
+                       headers,
                        json.toUtf8(),
                        "application/json");
 }
@@ -89,24 +94,52 @@ void ClayWebAccess::handleNetworkError(QNetworkReply* reply, const QString& erro
 
 void ClayWebAccess::handleAuthorization(QNetworkRequest &req, const QString &authString)
 {
-    auto authParts = authString.split(" ", Qt::SkipEmptyParts);
-    if (authParts.size() == 2) {
-        auto authType = authParts[0];
-        auto authStr = authParts[1];
-        if (authType == "Bearer") {
-            auto resAuth = resolveAuthString(authStr);
-            req.setRawHeader("Authorization",
-                             QString("Bearer %1").arg(resAuth).toUtf8());
-        }
-        else {
-            qWarning() << "Skipping unsupported auth type: " << authString;
-        }
+    // The scheme is the first word, the credential is everything after it.
+    // Splitting by hand instead of by QString::split keeps a Basic password
+    // that contains spaces intact - it is the last field and never a
+    // delimiter.
+    auto schemeEnd = authString.indexOf(' ');
+    if (schemeEnd < 0) return;
+    auto authType = authString.left(schemeEnd);
+    auto credential = authString.mid(schemeEnd + 1).trimmed();
+    if (credential.isEmpty()) return;
+
+    if (authType == "Bearer") {
+        auto resAuth = resolveAuthString(credential);
+        req.setRawHeader("Authorization",
+                         QString("Bearer %1").arg(resAuth).toUtf8());
+    }
+    else if (authType == "Basic") {
+        // "<user> <password>", space separated rather than the ":" of the
+        // header itself: a "file://" reference contains a colon and would
+        // otherwise be split in the middle. Each field is resolved on its
+        // own, so a password can come from a file while the user stays inline.
+        auto userEnd = credential.indexOf(' ');
+        auto user = userEnd < 0 ? credential : credential.left(userEnd);
+        auto password = userEnd < 0 ? QString() : credential.mid(userEnd + 1);
+        auto pair = QString("%1:%2").arg(resolveAuthString(user),
+                                         resolveAuthString(password));
+        req.setRawHeader("Authorization", "Basic " + pair.toUtf8().toBase64());
+    }
+    else {
+        qWarning() << "Skipping unsupported auth type: " << authString;
+    }
+}
+
+void ClayWebAccess::applyHeaders(QNetworkRequest &req, const QVariantMap &headers)
+{
+    for (auto it = headers.cbegin(); it != headers.cend(); ++it)
+    {
+        auto value = resolveAuthString(it.value().toString());
+        if (it.key().isEmpty() || value.isEmpty()) continue;
+        req.setRawHeader(it.key().toUtf8(), value.toUtf8());
     }
 }
 
 int ClayWebAccess::sendRequest(QNetworkAccessManager::Operation operation,
                                const QString &url,
                                const QString &authString,
+                               const QVariantMap &headers,
                                const QByteArray &data,
                                const QString &contentType)
 {
@@ -116,6 +149,7 @@ int ClayWebAccess::sendRequest(QNetworkAccessManager::Operation operation,
         req.setHeader(QNetworkRequest::ContentTypeHeader, contentType);
 
     handleAuthorization(req, authString);
+    applyHeaders(req, headers);
 
     QNetworkReply *reply = nullptr;
     switch (operation) {

--- a/plugins/clay_network/claywebaccess.h
+++ b/plugins/clay_network/claywebaccess.h
@@ -7,6 +7,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QMap>
+#include <QVariantMap>
 #include <QQmlComponent>
 
 /**
@@ -23,11 +24,23 @@ public:
     ClayWebAccess(QObject* parent = nullptr);
 
 public slots:
-    /** Performs an HTTP GET request, returns a unique request ID. */
-    int get(const QString& url, const QString& auth = "");
+    /**
+     *  Performs an HTTP GET request, returns a unique request ID.
+     *
+     *  \a auth is a space separated auth spec: "Bearer <token>" or
+     *  "Basic <user> <password>". \a headers are extra raw headers, e.g. an
+     *  API key header. Every value - token, user, password, header value -
+     *  may be given literally, as "env.<VARIABLE>" or as "file://<path>".
+     */
+    int get(const QString& url,
+            const QString& auth = "",
+            const QVariantMap& headers = QVariantMap());
 
     /** Performs an HTTP POST request, returns a unique request ID. */
-    int post(const QString& url, const QString& json, const QString& auth = "");
+    int post(const QString& url,
+             const QString& json,
+             const QString& auth = "",
+             const QVariantMap& headers = QVariantMap());
 
 signals:
     /** Signal emitted when a request is successfully processed. */
@@ -42,11 +55,13 @@ private slots:
 private:
     QString resolveAuthString(const QString &authStr);
     void handleAuthorization(QNetworkRequest &req, const QString &authString);
+    void applyHeaders(QNetworkRequest &req, const QVariantMap &headers);
     int remPendingRequest(QNetworkReply *reply);
     void handleNetworkError(QNetworkReply *reply, const QString &errorDetails);
     int sendRequest(QNetworkAccessManager::Operation operation,
                     const QString &url,
                     const QString &authString = "",
+                    const QVariantMap &headers = QVariantMap(),
                     const QByteArray &data = QByteArray(),
                     const QString &contentType = ""
                     );

--- a/plugins/clay_network/tests/CMakeLists.txt
+++ b/plugins/clay_network/tests/CMakeLists.txt
@@ -19,6 +19,40 @@ target_link_libraries(tst_network_serialization PRIVATE
 add_test(NAME network_serialization COMMAND tst_network_serialization)
 set_tests_properties(network_serialization PROPERTIES LABELS "network;unit")
 
+# HTTP auth tests - drive ClayHttpClient against a local echo server and assert
+# the headers that actually go out. ClayWebAccess is compiled in and registered
+# by hand and the QML file is loaded from the source tree, so this needs
+# neither the built plugin nor a QML import path (#85).
+find_package(Qt6 REQUIRED COMPONENTS Gui Network Qml Quick)
+
+add_executable(tst_http_auth
+    tst_http_auth.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../claywebaccess.cpp
+)
+
+set_target_properties(tst_http_auth PROPERTIES AUTOMOC ON)
+
+target_include_directories(tst_http_auth PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+target_compile_definitions(tst_http_auth PRIVATE
+    CLAY_HTTP_CLIENT_QML="${CMAKE_CURRENT_SOURCE_DIR}/../ClayHttpClient.qml"
+)
+
+target_link_libraries(tst_http_auth PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Network
+    Qt6::Qml
+    Qt6::Quick
+    Qt6::Test
+)
+
+add_test(NAME network_http_auth COMMAND tst_http_auth)
+set_tests_properties(network_http_auth PROPERTIES
+    LABELS "network;unit"
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
 # Net Gym - multi-instance state-sync integration test driven through the
 # inspector protocol (needs the loader binary and Python). The loader target
 # is defined after the plugins dir, so gate on the tools condition - the

--- a/plugins/clay_network/tests/tst_http_auth.cpp
+++ b/plugins/clay_network/tests/tst_http_auth.cpp
@@ -1,0 +1,214 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+
+#include <QtTest/QtTest>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QQmlEngine>
+#include <QQmlComponent>
+#include <QJSValue>
+#include <QSharedPointer>
+
+#include "claywebaccess.h"
+
+namespace {
+
+/**
+ * @brief Records the head of every HTTP request it receives and answers 200.
+ *
+ * Enough of a server to assert what a client actually put on the wire; it
+ * never looks at a body, so the suite drives GET endpoints only.
+ */
+class EchoServer : public QTcpServer
+{
+    Q_OBJECT
+
+public:
+    explicit EchoServer(QObject* parent = nullptr) : QTcpServer(parent)
+    {
+        connect(this, &QTcpServer::newConnection, this, &EchoServer::onConnection);
+    }
+
+    QList<QByteArray> requestHeads;
+
+    /** Value of \a name in request \a index, or a null QByteArray if absent. */
+    QByteArray header(int index, const QByteArray& name) const
+    {
+        if (index < 0 || index >= requestHeads.size()) return {};
+        const auto lines = requestHeads[index].split('\n');
+        for (const auto& line : lines) {
+            const auto colon = line.indexOf(':');
+            if (colon < 0) continue;
+            if (line.left(colon).trimmed().toLower() == name.toLower())
+                return line.mid(colon + 1).trimmed();
+        }
+        return {};
+    }
+
+private slots:
+    void onConnection()
+    {
+        auto* socket = nextPendingConnection();
+        auto buffer = QSharedPointer<QByteArray>::create();
+        connect(socket, &QTcpSocket::readyRead, this, [this, socket, buffer]() {
+            buffer->append(socket->readAll());
+            const auto end = buffer->indexOf("\r\n\r\n");
+            if (end < 0) return;
+            requestHeads.append(buffer->left(end));
+            socket->write("HTTP/1.1 200 OK\r\n"
+                          "Content-Type: application/json\r\n"
+                          "Content-Length: 2\r\n"
+                          "Connection: close\r\n"
+                          "\r\n"
+                          "{}");
+            socket->flush();
+            socket->disconnectFromHost();
+        });
+        connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+    }
+};
+
+} // namespace
+
+/**
+ * @brief Asserts the headers ClayHttpClient sends for each auth scheme.
+ *
+ * ClayHttpClient.qml is loaded straight from the source tree and ClayWebAccess
+ * is registered by hand, so the suite needs neither the built plugin nor a QML
+ * import path.
+ */
+class TestHttpAuth : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void bearerTokenUnchanged();
+    void basicAuthHeader();
+    void basicAuthPasswordFromEnv();
+    void apiKeyHeaderVerbatim();
+    void apiKeyHeaderRenamed();
+    void apiKeyAlongsideBearerToken();
+    void noCredentialsNoAuthHeader();
+    void cleanup();
+
+private:
+    /** Creates a client with one "GET ping" endpoint and the given properties. */
+    QObject* createClient(const QVariantMap& props);
+    /** Calls api.ping() and waits until the server has seen the request. */
+    void callPing(QObject* client);
+
+    QQmlEngine engine_;
+    EchoServer server_;
+    QString baseUrl_;
+    std::vector<std::unique_ptr<QObject>> clients_;
+};
+
+void TestHttpAuth::initTestCase()
+{
+    qmlRegisterType<ClayWebAccess>("Clayground.Network", 1, 0, "ClayWebAccess");
+    QVERIFY2(server_.listen(QHostAddress::LocalHost),
+             qPrintable(server_.errorString()));
+    baseUrl_ = QString("http://127.0.0.1:%1").arg(server_.serverPort());
+}
+
+void TestHttpAuth::cleanup()
+{
+    server_.requestHeads.clear();
+    clients_.clear();
+}
+
+QObject* TestHttpAuth::createClient(const QVariantMap& props)
+{
+    QQmlComponent comp(&engine_, QUrl::fromLocalFile(CLAY_HTTP_CLIENT_QML));
+    auto* client = comp.create();
+    if (!client) {
+        qWarning() << comp.errorString();
+        return nullptr;
+    }
+    clients_.emplace_back(client);
+
+    client->setProperty("baseUrl", baseUrl_);
+    for (auto it = props.cbegin(); it != props.cend(); ++it)
+        client->setProperty(qPrintable(it.key()), it.value());
+    // Last, so the generated api object sees the finished configuration.
+    client->setProperty("endpoints", QVariantMap{{"ping", "GET ping"}});
+    return client;
+}
+
+void TestHttpAuth::callPing(QObject* client)
+{
+    QVERIFY(client);
+    auto api = client->property("api").value<QJSValue>();
+    auto ping = api.property("ping");
+    QVERIFY2(ping.isCallable(), "api.ping was not generated");
+    const auto result = ping.callWithInstance(api);
+    QVERIFY2(!result.isError(), qPrintable(result.toString()));
+    QTRY_VERIFY(!server_.requestHeads.isEmpty());
+}
+
+void TestHttpAuth::bearerTokenUnchanged()
+{
+    auto* client = createClient({{"bearerToken", "tok-123"}});
+    callPing(client);
+    QCOMPARE(server_.header(0, "Authorization"), QByteArray("Bearer tok-123"));
+}
+
+void TestHttpAuth::basicAuthHeader()
+{
+    auto* client = createClient({{"basicAuthUser", "alice"},
+                                 {"basicAuthPassword", "s3cret"}});
+    callPing(client);
+    // base64("alice:s3cret")
+    QCOMPARE(server_.header(0, "Authorization"),
+             QByteArray("Basic YWxpY2U6czNjcmV0"));
+    QCOMPARE(QByteArray::fromBase64(server_.header(0, "Authorization").mid(6)),
+             QByteArray("alice:s3cret"));
+}
+
+void TestHttpAuth::basicAuthPasswordFromEnv()
+{
+    qputenv("CLAY_TEST_BASIC_PASSWORD", "s3cret");
+    auto* client = createClient({{"basicAuthUser", "alice"},
+                                 {"basicAuthPassword", "env.CLAY_TEST_BASIC_PASSWORD"}});
+    callPing(client);
+    QCOMPARE(server_.header(0, "Authorization"),
+             QByteArray("Basic YWxpY2U6czNjcmV0"));
+    qunsetenv("CLAY_TEST_BASIC_PASSWORD");
+}
+
+void TestHttpAuth::apiKeyHeaderVerbatim()
+{
+    auto* client = createClient({{"apiKey", "abc123"}});
+    callPing(client);
+    QCOMPARE(server_.header(0, "X-API-Key"), QByteArray("abc123"));
+    QVERIFY(server_.header(0, "Authorization").isNull());
+}
+
+void TestHttpAuth::apiKeyHeaderRenamed()
+{
+    auto* client = createClient({{"apiKey", "abc123"},
+                                 {"apiKeyHeader", "X-Custom-Key"}});
+    callPing(client);
+    QCOMPARE(server_.header(0, "X-Custom-Key"), QByteArray("abc123"));
+    QVERIFY(server_.header(0, "X-API-Key").isNull());
+}
+
+void TestHttpAuth::apiKeyAlongsideBearerToken()
+{
+    auto* client = createClient({{"bearerToken", "tok-123"},
+                                 {"apiKey", "abc123"}});
+    callPing(client);
+    QCOMPARE(server_.header(0, "Authorization"), QByteArray("Bearer tok-123"));
+    QCOMPARE(server_.header(0, "X-API-Key"), QByteArray("abc123"));
+}
+
+void TestHttpAuth::noCredentialsNoAuthHeader()
+{
+    auto* client = createClient({});
+    callPing(client);
+    QVERIFY(server_.header(0, "Authorization").isNull());
+    QVERIFY(server_.header(0, "X-API-Key").isNull());
+}
+
+QTEST_MAIN(TestHttpAuth)
+#include "tst_http_auth.moc"


### PR DESCRIPTION
`ClayHttpClient` takes `basicAuthUser`/`basicAuthPassword` and `apiKey`/`apiKeyHeader` next to `bearerToken`, and `ClayWebAccess::get`/`post` gained an optional `headers` map to carry the key. `env.<VAR>` and `file://<path>` resolution now applies to every credential value, not just the bearer token.

- `handleAuthorization` splits scheme from credential at the first space instead of requiring exactly two tokens, and adds a `Basic <user> <password>` scheme that emits `Authorization: Basic <base64(user:password)>` — space separated, because a `file://` reference contains the colon the header itself uses
- `applyHeaders` writes the extra raw headers, so an API key travels in `X-API-Key` (renameable) and can accompany a bearer token rather than replace it
- credentials are read per call in `ClayHttpClient.qml` instead of being captured when the `api` object is generated — a token assigned after `endpoints` used to be silently dropped
- `bearerToken` wins over the basic properties; a request carries one `Authorization` header
- `plugins/clay_network/README.md` and `docs/docs/plugins/network.md` both documented the env prefix as `env:API_TOKEN`; the code reads `env.` and the sections I rewrote now say so

Verified:
- `ctest --preset default -R network` → 4/4 passed, exit 0 — answers the criterion "`ctest -R network` green"
- `ctest --preset default -R network_http_auth --verbose` → 9 passed, 0 failed; `basicAuthHeader` asserts `Basic YWxpY2U6czNjcmV0`, `apiKeyHeaderVerbatim` asserts `X-API-Key: abc123`, `bearerTokenUnchanged` asserts `Bearer tok-123` — answers "assert the received `Authorization: Basic …` value and the configured API-key header verbatim" and "bearer behavior unchanged"
- mutation check: commenting out `applyHeaders(req, headers)` → 3 failed (the API-key cases); renaming the `Basic` branch → 2 failed (the basic-auth cases). Restored and rebuilt, source diff clean
- `ctest --preset default` → 53/53 passed, exit 0
- `8 files changed, 437 insertions(+), 36 deletions(-)`

Not verified: Windows and WASM — built and run on macOS 26.6.2 / Qt 6.11.1 only. `testsbx_plugin` failed on the first run of this fresh worktree with `module "Clayground.MyPlugin" plugin "MyPluginplugin" not found`; that is the known first-parallel-build artifact (#188 family), fixed by relinking `sbx_plugin`, and it passes in the two runs since.

<details><summary>Test names, the echo-server test setup, and what was left alone</summary>

New CTest case `network_http_auth` (`plugins/clay_network/tests/tst_http_auth.cpp`), labels `network;unit`:

```
PASS   : TestHttpAuth::bearerTokenUnchanged()
PASS   : TestHttpAuth::basicAuthHeader()
PASS   : TestHttpAuth::basicAuthPasswordFromEnv()
PASS   : TestHttpAuth::apiKeyHeaderVerbatim()
PASS   : TestHttpAuth::apiKeyHeaderRenamed()
PASS   : TestHttpAuth::apiKeyAlongsideBearerToken()
PASS   : TestHttpAuth::noCredentialsNoAuthHeader()
Totals: 9 passed, 0 failed, 0 skipped, 0 blacklisted, 366ms
```

The suite runs a `QTcpServer` that records each request head and answers 200,
then drives a real `ClayHttpClient`: `ClayHttpClient.qml` is loaded from the
source tree by file URL and `ClayWebAccess` is registered with
`qmlRegisterType`, so the test needs neither the built plugin nor a QML import
path — and therefore is not subject to the Windows `IMPORTS_BUILT_MODULE`
exclusion in #192.

Left alone deliberately: `plugins/clay_network/demo/SandboxHttpClient.qml`
still demonstrates only the bearer path, and `ClayWebAccess` still has no
`PUT`/`DELETE`/`PATCH` — both outside this issue.

</details>

Closes #85
