### PR TITLE
CircleBody: a round collider for clay_physics

### DIFF
--- a/plugins/clay_physics/CMakeLists.txt
+++ b/plugins/clay_physics/CMakeLists.txt
@@ -9,6 +9,7 @@ clay_plugin( Physics
     VERSION 1.0
 
     QML_FILES
+            CircleBody.qml
             CollisionTracker.qml
             ImageBoxBody.qml
             PhysicsItem.qml
@@ -21,3 +22,11 @@ clay_plugin( Physics
         Qt::Quick
         Qt::Qml
 )
+
+# QML checks on the body types. The suite drives a Box2D World by hand
+# (running: false + step()) so the outcome does not depend on frame timing.
+include(claytest)
+# IMPORTS_BUILT_MODULE: Box2D and Clayground.Physics are loaded as built
+# plugins from bin/qml, not imported as QML sources (#192).
+clay_add_qml_test(physics_qml IMPORTS_BUILT_MODULE
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/qml)

--- a/plugins/clay_physics/CircleBody.qml
+++ b/plugins/clay_physics/CircleBody.qml
@@ -1,0 +1,128 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+
+/*!
+    \qmltype CircleBody
+    \inqmlmodule Clayground.Physics
+    \brief Circle-shaped physics body with visual representation.
+
+    CircleBody combines a round visual with a Box2D circle fixture. Unlike a
+    box fixture it has no corners to snag on, which is what makes it the
+    collider of choice for characters and projectiles moving along walls.
+
+    Example usage:
+    \qml
+    import Clayground.Physics
+    import Box2D
+
+    CircleBody {
+        xWu: 5; yWu: 5
+        radiusWu: 0.5
+        color: "red"
+        bodyType: Body.Dynamic
+        density: 1
+        friction: 0.3
+        restitution: 0.5
+    }
+    \endqml
+
+    \note \c xWu and \c yWu address the bounding box's corner, exactly as they
+    do for RectBoxBody - not the circle's centre. The centre sits \c radiusWu
+    away from both.
+
+    \sa PhysicsItem, RectBoxBody
+*/
+import QtQuick
+import Box2D
+
+PhysicsItem {
+    id: theItem
+
+    /*!
+        \qmlproperty real CircleBody::radiusWu
+        \brief Radius in world units.
+    */
+    property real radiusWu: 0.5
+
+    // Box2D's round shape is a circle, not an ellipse, so the item is kept
+    // square: visual and fixture both read radiusWu and cannot drift apart.
+    widthWu: radiusWu * 2
+    heightWu: radiusWu * 2
+
+    /*!
+        \qmlproperty Fixture CircleBody::fixture
+        \brief The Box2D circle fixture.
+    */
+    property alias fixture: circle
+
+    /*!
+        \qmlproperty color CircleBody::color
+        \brief Fill color of the circle.
+    */
+    property alias color: disc.color
+
+    /*!
+        \qmlproperty Border CircleBody::border
+        \brief Border properties of the circle.
+    */
+    property alias border: disc.border
+
+    /*!
+        \qmlproperty real CircleBody::density
+        \brief Fixture density affecting mass.
+    */
+    property alias density: circle.density
+
+    /*!
+        \qmlproperty real CircleBody::friction
+        \brief Friction coefficient (0-1).
+    */
+    property alias friction: circle.friction
+
+    /*!
+        \qmlproperty real CircleBody::restitution
+        \brief Bounciness coefficient (0-1).
+    */
+    property alias restitution: circle.restitution
+
+    /*!
+        \qmlproperty bool CircleBody::sensor
+        \brief If true, detects collisions without physical response.
+    */
+    property alias sensor: circle.sensor
+
+    /*!
+        \qmlproperty int CircleBody::categories
+        \brief Collision category bits.
+    */
+    property alias categories: circle.categories
+
+    /*!
+        \qmlproperty int CircleBody::collidesWith
+        \brief Collision mask bits.
+    */
+    property alias collidesWith: circle.collidesWith
+
+    /*!
+        \qmlproperty int CircleBody::groupIndex
+        \brief Collision group index.
+    */
+    property alias groupIndex: circle.groupIndex
+
+    Rectangle {
+        id: disc
+        anchors.fill: parent
+        radius: width * 0.5
+    }
+
+    fixtures: [
+        Circle {
+            id: circle
+            // Box2D places a circle by its centre in the item's local pixel
+            // frame - unlike Box, which takes a corner plus a size. The item
+            // is square, so the centre is its middle.
+            x: theItem.width * 0.5
+            y: theItem.height * 0.5
+            radius: theItem.width * 0.5
+        }
+    ]
+}

--- a/plugins/clay_physics/README.md
+++ b/plugins/clay_physics/README.md
@@ -18,6 +18,7 @@ import Box2D
 
 - **PhysicsItem** - Base component for physics-enabled items with world unit support
 - **RectBoxBody** - Rectangle-shaped physics body with visual representation
+- **CircleBody** - Circle-shaped physics body, for colliders that must not snag on corners
 - **ImageBoxBody** - Image-based physics body with box collision
 - **VisualizedPolyBody** - Polygon physics body integrated with Canvas visualization
 - **CollisionTracker** - Tracks entities colliding with a fixture
@@ -92,6 +93,25 @@ RectBoxBody {
     }
 }
 ```
+
+### Round Collider
+
+```qml
+CircleBody {
+    xWu: 5
+    yWu: 5
+    radiusWu: 0.5
+    color: "red"
+
+    bodyType: Body.Dynamic
+    density: 1
+    friction: 0.3
+    restitution: 0.5
+}
+```
+
+`xWu`/`yWu` address the bounding box's corner, as they do for `RectBoxBody`;
+the circle's centre sits `radiusWu` away from both.
 
 ### Collectible Items
 

--- a/plugins/clay_physics/clay_physics.qdoc
+++ b/plugins/clay_physics/clay_physics.qdoc
@@ -143,6 +143,71 @@
 */
 
 /*!
+    \qmltype CircleBody
+    \inqmlmodule Clayground.Physics
+    \brief Circle-shaped physics body with visual representation.
+
+    CircleBody combines a round visual with a Box2D circle fixture. Unlike a
+    box fixture it has no corners to snag on, which is what makes it the
+    collider of choice for characters and projectiles moving along walls.
+
+    \c xWu and \c yWu address the bounding box's corner, exactly as they do
+    for RectBoxBody - not the circle's centre. The centre sits \c radiusWu
+    away from both.
+
+    Example usage:
+    \qml
+    import Clayground.Physics
+    import Box2D
+
+    CircleBody {
+        xWu: 5; yWu: 5
+        radiusWu: 0.5
+        color: "red"
+        bodyType: Body.Dynamic
+        density: 1
+        friction: 0.3
+        restitution: 0.5
+    }
+    \endqml
+
+    \section1 Properties
+
+    \qmlproperty real CircleBody::radiusWu
+    Radius in world units. Drives both the fixture and the visual.
+
+    \qmlproperty Fixture CircleBody::fixture
+    The Box2D circle fixture.
+
+    \qmlproperty color CircleBody::color
+    Fill color of the circle.
+
+    \qmlproperty Border CircleBody::border
+    Border properties of the circle.
+
+    \qmlproperty real CircleBody::density
+    Fixture density affecting mass.
+
+    \qmlproperty real CircleBody::friction
+    Friction coefficient (0-1).
+
+    \qmlproperty real CircleBody::restitution
+    Bounciness coefficient (0-1).
+
+    \qmlproperty bool CircleBody::sensor
+    If true, detects collisions without physical response.
+
+    \qmlproperty int CircleBody::categories
+    Collision category bits.
+
+    \qmlproperty int CircleBody::collidesWith
+    Collision mask bits.
+
+    \qmlproperty int CircleBody::groupIndex
+    Collision group index.
+*/
+
+/*!
     \qmltype ImageBoxBody
     \inqmlmodule Clayground.Physics
     \brief Image-based physics body with Box2D box collision.

--- a/plugins/clay_physics/tests/qml/tst_circlebody.qml
+++ b/plugins/clay_physics/tests/qml/tst_circlebody.qml
@@ -1,0 +1,137 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+
+import QtQuick
+import QtTest
+import Box2D
+import Clayground.Physics
+
+// A circle fixture rolls down an incline; a box fixture of the same size and
+// friction stays where it landed. That difference is the whole reason for
+// CircleBody to exist, and it is the one thing a rounded-corner Rectangle
+// over a Box fixture could not reproduce.
+//
+// The World is stepped by hand (running: false + step()) so the outcome does
+// not depend on frame timing or on how long the test host takes per frame.
+TestCase {
+    id: testCase
+    name: "CircleBody"
+
+    readonly property real ppu: 20          // pixels per world unit
+    readonly property real rampAngleDeg: 20 // screen-clockwise: downhill is +x
+    readonly property int stepCount: 120    // 2 s at 1/60
+
+    World {
+        id: physicsWorld
+        gravity: Qt.point(0, 9.81)  // metres/s^2, +y is screen-down
+        timeStep: 1/60
+        // 1 world unit = 1 metre, which keeps the expected roll distance
+        // computable from the incline angle alone.
+        pixelsPerMeter: testCase.ppu
+        running: false
+    }
+
+    // Two identical ramps side by side, so the rolling body can never reach
+    // the other one; each body starts at the same place on its own ramp.
+    Item {
+        id: room
+        width: 40 * testCase.ppu
+        height: 20 * testCase.ppu
+
+        RectBoxBody {
+            id: rampA
+            world: physicsWorld
+            pixelPerUnit: testCase.ppu
+            xWu: 1; yWu: 10
+            widthWu: 16; heightWu: 0.5
+            rotation: testCase.rampAngleDeg
+            bodyType: Body.Static
+            friction: 1.0
+        }
+
+        RectBoxBody {
+            id: rampB
+            world: physicsWorld
+            pixelPerUnit: testCase.ppu
+            xWu: 21; yWu: 10
+            widthWu: 16; heightWu: 0.5
+            rotation: testCase.rampAngleDeg
+            bodyType: Body.Static
+            friction: 1.0
+        }
+
+        CircleBody {
+            id: ball
+            world: physicsWorld
+            pixelPerUnit: testCase.ppu
+            radiusWu: 0.5
+            xWu: 2.5
+            yWu: testCase.dropYWu(rampA, 3.0, 1.0)
+            bodyType: Body.Dynamic
+            density: 1; friction: 1.0; restitution: 0
+        }
+
+        RectBoxBody {
+            id: crate
+            world: physicsWorld
+            pixelPerUnit: testCase.ppu
+            widthWu: 1; heightWu: 1
+            xWu: 22.5
+            yWu: testCase.dropYWu(rampB, 23.0, 1.0)
+            bodyType: Body.Dynamic
+            density: 1; friction: 1.0; restitution: 0
+            // Laid flush with the incline rather than axis-aligned: a box
+            // dropped on one corner tips itself flat, and that settling moves
+            // x for reasons that have nothing to do with rolling. Assigned
+            // rather than bound because Box2D writes rotation back on every
+            // step and a binding would be fighting it.
+            Component.onCompleted: rotation = testCase.rampAngleDeg
+        }
+    }
+
+    // World-unit y of the top edge of a sizeWu x sizeWu body whose underside
+    // hovers a tenth of a unit over the ramp's upper surface at xWu. yWu
+    // addresses the bounding box's top edge, so the body centre is derived
+    // first: rotation happens about that centre and leaves it in place.
+    function dropYWu(ramp, xWu, sizeWu) {
+        var rad = rampAngleDeg * Math.PI / 180;
+        var rampCentreXWu = ramp.xWu + ramp.widthWu * 0.5;
+        var rampCentreYWu = ramp.yWu - ramp.heightWu * 0.5;
+        // Downhill is +x, so a point left of the ramp's centre sits higher.
+        var midlineYWu = rampCentreYWu + (rampCentreXWu - xWu) * Math.tan(rad);
+        // Half the ramp's thickness plus half the body, both measured along
+        // the surface normal and then expressed as a vertical offset.
+        var clearanceWu = (ramp.heightWu * 0.5 + sizeWu * 0.5) / Math.cos(rad);
+        return midlineYWu + clearanceWu + 0.1 + sizeWu * 0.5;
+    }
+
+    function stepWorld(n) {
+        for (var i = 0; i < n; ++i) physicsWorld.step();
+    }
+
+    function test_circleRollsDownAnInclineWhereABoxDoesNot() {
+        var ballStartXWu = ball.xWu;
+        var crateStartXWu = crate.xWu;
+
+        stepWorld(stepCount);
+
+        var ballTravel = Math.abs(ball.xWu - ballStartXWu);
+        var crateTravel = Math.abs(crate.xWu - crateStartXWu);
+
+        verify(ballTravel > 2.0,
+               "circle should roll down the incline, moved " + ballTravel + " wu");
+        verify(crateTravel < 0.5,
+               "box should stay put on the incline, moved " + crateTravel + " wu");
+        // Not merely "the circle moved more": the two outcomes have to differ
+        // in kind, or a slightly slipperier box would also pass.
+        verify(ballTravel > 4 * crateTravel,
+               "circle " + ballTravel + " wu vs box " + crateTravel + " wu");
+    }
+
+    // The fixture has to be a real Circle sized from radiusWu - a Box fixture
+    // behind a round Rectangle would pass the rolling test only by accident.
+    function test_fixtureIsACircleSizedFromRadiusWu() {
+        compare(ball.fixture.radius, ball.radiusWu * testCase.ppu);
+        compare(ball.widthWu, ball.radiusWu * 2);
+        compare(ball.heightWu, ball.radiusWu * 2);
+    }
+}


### PR DESCRIPTION
`CircleBody` puts Box2D's `Circle` fixture behind a `PhysicsItem`, so a body can now have a round collider instead of a box or a polygon. `radiusWu` is the one size knob: it drives `widthWu`/`heightWu` and the fixture radius together, so the visual and the collider cannot drift apart.

- `plugins/clay_physics/CircleBody.qml` — the same alias set as `RectBoxBody` (`density`, `friction`, `restitution`, `sensor`, `categories`, `collidesWith`, `groupIndex`, `color`, `border`, `fixture`), plus `radiusWu`
- `plugins/clay_physics/tests/qml/tst_circlebody.qml` — a new suite, and the first one in this plugin: it drives the `World` by hand (`running: false` plus `step()`), so the result does not depend on frame timing
- `plugins/clay_physics/CMakeLists.txt` registers the suite as `qml_physics_qml` via `clay_add_qml_test(... IMPORTS_BUILT_MODULE)`, which follows `clay_world` in staying off on Windows (#192)
- `clay_physics.qdoc` and the plugin `README.md` document the type

Verified:
- criterion "a dynamic `CircleBody` dropped onto an inclined static `RectBoxBody` must roll where a `RectBoxBody` stays put": in `test_circleRollsDownAnInclineWhereABoxDoesNot` the circle travelled 4.204 wu and the box 0.0035 wu over 120 hand-driven steps on two identical 20° ramps
- the same test falsifies: swapping `CircleBody`'s `Circle` for a `Box` drops the travel to 0.127 wu and the suite goes red — `Totals: 3 passed, 1 failed`
- criterion "`ctest --test-dir build -R physics` passes": `ctest --preset default -R physics` → `1/1 Test #17: qml_physics_qml ... Passed`, exit 0; verbose run shows `Totals: 4 passed, 0 failed, 0 skipped`
- criterion "`\qmltype CircleBody` qdoc block present": `cmake --build build --target docs` generates `qml-clayground-physics-circlebody.html` beside `qml-clayground-physics-rectboxbody.html`
- whole suite: `ctest --preset default` → `100% tests passed out of 54`, exit 0
- `cmake --build --preset default` → exit 0
- `5 files changed, 359 insertions(+)`

Not verified: Windows and Linux — macOS only (Qt 6.11.1, `arm64`); and the visual itself was never rendered, only the fixture's behaviour was measured.

<details><summary>The circle visual, the qdoc warning picture, and how the ramp scene is set up</summary>

**The visual is a `Rectangle`, not a `Shape`.** The issue's design constraints ask for an "Ellipse visual (via QtQuick.Shapes or canvas)" *and* for "no new dependencies", and those pull apart. I took the second: the item is square by construction (`widthWu` and `heightWu` are both `radiusWu * 2`), so `Rectangle { radius: width * 0.5 }` renders an exact circle and `clay_physics` keeps its current three `LINK_LIBS` and gains no `QtQuick.Shapes` import. Box2D has no ellipse shape either, so a non-round visual could never have matched the collider anyway. Say the word and it becomes a `Shape` with a `PathAngleArc`.

**The qdoc warnings.** The docs build is not warning-free today — several hundred pre-existing ones. `CircleBody` adds 11, all of the form `No output generated for QML property 'CircleBody::x' because 'CircleBody' is undocumented`, which is exactly the pattern the neighbours already produce: `RectBoxBody` 11, `ImageBoxBody` 13. No new *kind* of warning, and the one `Unable to parse QML snippet` warning in `clay_physics.qdoc` is at line 355, inside the pre-existing `PhysicsUtils` block.

**The test scene.** Two identical 20° ramps side by side, each a static `RectBoxBody`, friction 1.0 — separate ramps so the rolling body can never reach the other one. On ramp A a dynamic `CircleBody` (`radiusWu: 0.5`), on ramp B a dynamic `RectBoxBody` of the same 1x1 wu footprint, both density 1, friction 1.0, restitution 0, both hovering 0.1 wu over the surface at the same relative spot. `tan(20°) = 0.36` is well under the combined friction, so the box has no reason to slide; the circle has no such threshold. The box is laid flush with the incline rather than axis-aligned, because a box dropped on one corner tips itself flat and that settling moves `x` for reasons that have nothing to do with rolling — it is assigned in `Component.onCompleted` rather than bound, since Box2D writes `rotation` back on every step.

The assertions are a threshold on each body separately plus a ratio between them (`ballTravel > 4 * crateTravel`), so a merely slipperier box cannot pass.

**One thing worth knowing if you rerun this.** Plugin QML is baked into the plugin's Qt resources, so after editing `CircleBody.qml` the plugin has to relink before `ctest` means anything — a restore that preserved the old mtime once made CMake skip the rebuild and the suite reported the previous build's result.

</details>

Closes #107
