### PR TITLE
character3d: loadable move sets, and a martial-arts set of fourteen moves

### DIFF
--- a/plugins/clay_character3d/CMakeLists.txt
+++ b/plugins/clay_character3d/CMakeLists.txt
@@ -69,6 +69,7 @@ clay_plugin( Character3D
         animation/IdleAnim.qml
         animation/UseAnim.qml
         animation/FightAnim.qml
+        animation/MoveSet.qml
         animation/TalkGestureAnim.qml
         animation/GestureAnim.qml
         animation/GazeAnim.qml
@@ -77,6 +78,12 @@ clay_plugin( Character3D
         animation/EulerAnim.qml
         animation/HeadEulerAnim.qml
         animation/PosAndEulerAnim.qml
+
+        # Loadable Move Sets
+        # Optional, on top of the basic set above: loaded onto a character by
+        # Character::moveSet rather than instantiated with every one of them.
+        movesets/MartialArts.qml
+        movesets/martialarts.js
 
         # Control System
         control/CharacterCamera.qml
@@ -107,6 +114,14 @@ clay_add_node_test(character3d_gait SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/animation
 # (a guard keeps both fists above the elbows, a punch closes the hand, a
 # working stroke actually moves) are numbers rather than screenshots.
 clay_add_node_test(character3d_action SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/animation/action.test.js)
+
+# The martial-arts move set is Qt-free for the same reason again, and it is
+# the reason the set is worth having as a model at all: "a front kick puts the
+# foot above the hip", "no crouch leaves a foot under the floor" and "the
+# get-up starts exactly where the knockdown ended" are numbers, and all three
+# were wrong at some point while the set was being written.
+clay_add_node_test(character3d_martialarts
+                   SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/movesets/martialarts.test.js)
 
 # Behaviour suites. GazeAnim and ListenAnim ask their head and speaker for a
 # handful of properties and nothing else, so they are tested against stubs -

--- a/plugins/clay_character3d/Character.qml
+++ b/plugins/clay_character3d/Character.qml
@@ -206,13 +206,32 @@ BodyPartsGroup {
 
         \sa handPose, gaitHandPose, ActionCycleAnim::handPose
     */
-    readonly property string actionHandPose: _fightAnim.handPose !== "" ? _fightAnim.handPose
+    readonly property string actionHandPose: _character.moveHandPose !== "" ? _character.moveHandPose
+                                           : _fightAnim.handPose !== "" ? _fightAnim.handPose
                                            : _useAnim.handPose
 
     readonly property real gaitLift: _walkAnim.running ? _walkAnim.lift
                                    : _runAnim.running ? _runAnim.lift
                                    : _character._heldLift
     property real _heldLift: 0
+
+    /*!
+        \qmlproperty real Character::bodyDrift
+        \readonly
+        \brief How far the body has travelled forward over its own feet, in
+               the character's own units.
+
+        The companion of \l gaitLift on the other axis, and written by the
+        same animators: a step, a jump or a stagger moves the whole figure -
+        feet included - relative to the character's position, and comes back
+        to zero by the end of the move. Carrying the character itself across
+        the floor is the caller's business; nothing here ever writes
+        \c position.
+
+        \sa gaitLift, moveSet
+    */
+    readonly property real bodyDrift: _character._heldDrift
+    property real _heldDrift: 0
 
     /*!
         \qmlmethod var Character::gaitPoseAt(string base, real t)
@@ -338,6 +357,217 @@ BodyPartsGroup {
     function applyActionPose(action, t) {
         const a = action === "fight" ? _fightAnim : _useAnim
         a.apply(t)
+    }
+
+    // ============================================================================
+    // LOADABLE MOVE SETS
+    // ============================================================================
+    //
+    // Everything above this line is the BASIC SET: walking, running, standing,
+    // gazing, listening, gesturing, talking, working and boxing are what a
+    // character IS, every game wants them, and they are always-resident
+    // children of this file. A MOVE SET is what a character KNOWS - a martial
+    // art, a dance, a trade's hand-work. One game wants it and the next does
+    // not, so it is loaded onto a character on demand, replaces whatever was
+    // loaded before it, and can be unloaded again by clearing moveSet.
+
+    /*!
+        \qmlproperty string Character::moveSet
+        \brief The loadable move set on this character, "" for none.
+
+        Either the name of a set that ships with the plugin - see
+        \l shippedMoveSets, currently \c {"martial arts"} - or the URL of a
+        \l MoveSet QML file of your own. Setting it loads the set and drops
+        whatever was loaded before; setting it to "" unloads.
+
+        Loading does not itself move the character. Play something with
+        \l playMove():
+
+        \qml
+        Character {
+            id: fighter
+            moveSet: "martial arts"
+            Component.onCompleted: fighter.playMove("stance")
+        }
+        \endqml
+
+        A set only runs while \l activity is Idle, exactly as a gesture does:
+        \l playMove() puts the activity back to Idle rather than quietly doing
+        nothing, and starting any other activity drops the move.
+
+        \sa playMove(), moves, MoveSet, MartialArts
+    */
+    property string moveSet: ""
+
+    /*!
+        \qmlproperty var Character::shippedMoveSets
+        \readonly
+        \brief The sets that ship with the plugin, as a map of name to the URL
+               \l moveSet resolves it to.
+    */
+    readonly property var shippedMoveSets: ({
+        "martial arts": Qt.resolvedUrl("movesets/MartialArts.qml")
+    })
+
+    /*!
+        \qmlproperty var Character::moves
+        \readonly
+        \brief What the loaded set offers: a list of
+               \c {{name, label, group, loop, holds}}, empty when no set is
+               loaded.
+
+        Enough for a UI to build a row of buttons without knowing what the set
+        is about.
+    */
+    readonly property var moves: _character._moveSetItem
+                               ? _character._moveSetItem.moves : []
+
+    /*!
+        \qmlproperty string Character::moveSetName
+        \brief What the loaded set calls itself, "" when none is loaded.
+    */
+    readonly property string moveSetName: _character._moveSetItem
+                                        ? _character._moveSetItem.name : ""
+
+    /*!
+        \qmlproperty string Character::activeMove
+        \readonly
+        \brief The move being played, or the one whose last frame is being
+               held; "" when nothing is.
+    */
+    readonly property string activeMove: _character._moveSetItem
+                                       ? _character._moveSetItem.move : ""
+
+    /*!
+        \qmlproperty bool Character::movePlaying
+        \readonly
+        \brief True while a move is actually animating - false while a
+               knockdown lies on the floor, which \l moveHolding is for.
+    */
+    readonly property bool movePlaying: _character._moveSetItem
+                                      ? _character._moveSetItem.playing : false
+
+    /*!
+        \qmlproperty bool Character::moveHolding
+        \readonly
+        \brief True while the loaded set owns the joints - playing, or sitting
+               on the last frame of a move that holds.
+    */
+    readonly property bool moveHolding: _character._moveSetItem
+                                      ? _character._moveSetItem.holding : false
+
+    /*!
+        \qmlproperty string Character::moveHandPose
+        \readonly
+        \brief What the running move wants the hands to be doing, "" when no
+               move is running. Folded into \l actionHandPose.
+    */
+    readonly property string moveHandPose: _character._moveSetItem
+                                         ? _character._moveSetItem.handPose : ""
+
+    /*!
+        \qmlsignal Character::moveFinished(string move)
+        \brief Emitted when a one-shot move of the loaded set reaches its end.
+    */
+    signal moveFinished(string move)
+
+    /*!
+        \qmlmethod bool Character::playMove(string move)
+        \brief Plays \a move of the loaded set. Returns false, and does
+               nothing, when no set is loaded or the set has no such move.
+
+        A move owns the whole body, so this drops any held gesture and puts
+        \l activity back to Idle first - a call that quietly did nothing while
+        a walk was running is one nobody can tell from a broken move.
+    */
+    function playMove(move) {
+        if (!_character._moveSetItem)
+            return false
+        _character.activity = Character.Activity.Idle
+        _gestureAnim.drop()
+        return _character._moveSetItem.play(move)
+    }
+
+    /*!
+        \qmlmethod void Character::stopMove()
+        \brief Stops the running move and lets go of the joints, which the
+               idle pose then takes back to standing.
+    */
+    function stopMove() {
+        if (_character._moveSetItem)
+            _character._moveSetItem.stop()
+    }
+
+    /*!
+        \qmlmethod var Character::movePoseAt(string move, real t)
+        \brief The joint angles \a move of the loaded set holds at phase
+               \a t, 0..1, with nothing running. Null when there is no such
+               move.
+
+        Pure, and the same answer the running move gives at that moment - the
+        set plays this very function.
+
+        \sa applyMovePose(), actionPoseAt()
+    */
+    function movePoseAt(move, t) {
+        return _character._moveSetItem
+             ? _character._moveSetItem.poseAt(move, t) : null
+    }
+
+    /*!
+        \qmlmethod void Character::applyMovePose(string move, real t)
+        \brief Freezes the joints at phase \a t of \a move.
+
+        For looking, not for playing, exactly as \l applyActionPose() is: a
+        row of characters frozen at successive phases is the move on one
+        sheet.
+    */
+    function applyMovePose(move, t) {
+        if (_character._moveSetItem)
+            _character._moveSetItem.apply(move, t)
+    }
+
+    // The loaded set, and the one place it is built. Created in JS rather than
+    // through a Loader: a Loader is an Item and this file is a 3D Node, and a
+    // set is a plain QtObject that needs no place in either scene - only an
+    // owner to be destroyed with.
+    property var _moveSetItem: null
+
+    onMoveSetChanged: _character._loadMoveSet()
+
+    function _loadMoveSet() {
+        if (_character._moveSetItem) {
+            _character._moveSetItem.stop()
+            _character._moveSetItem.destroy()
+            _character._moveSetItem = null
+        }
+        const want = _character.moveSet
+        if (want === "")
+            return
+        const shipped = _character.shippedMoveSets[want]
+        const src = shipped === undefined ? want : shipped
+        const comp = Qt.createComponent(src, Component.PreferSynchronous)
+        if (comp.status !== Component.Ready) {
+            console.warn("Character: cannot load move set '" + want + "': "
+                         + comp.errorString())
+            return
+        }
+        _character._moveSetItem = comp.createObject(_character, { entity: _character })
+        if (!_character._moveSetItem) {
+            console.warn("Character: move set '" + want + "' did not instantiate")
+            return
+        }
+        _character._moveSetItem.intensity = Qt.binding(function () {
+            return _character.actionIntensity
+        })
+        _character._moveSetItem.finished.connect(_character.moveFinished)
+        // The idle pose has to be told to let go and to take over again; the
+        // gesture layer is handed over the same way.
+        _character._moveSetItem.holdingChanged.connect(function () {
+            if (!_character._moveSetItem.holding
+                && _character.activity === Character.Activity.Idle)
+                _idleAnim.restart()
+        })
     }
 
     // Bounding box dimensions (derived from body parts)
@@ -1484,8 +1714,12 @@ BodyPartsGroup {
         // Position torso above legs, feet, and hip - plus whatever the gait
         // is lifting the whole figure by this instant. Everything hangs off
         // the torso, so this is the figure's bounce, feet included.
+        // Position torso above legs, feet and hip - plus whatever the gait or
+        // a move is lifting the whole figure by this instant, and however far
+        // forward a step or a jump has carried it. Everything hangs off the
+        // torso, so this is the figure's bounce and its travel, feet included.
         basePos: Qt.vector3d(0, _character.legHeight + _character.footHeight + _hip.height
-                                + _character.gaitLift, 0)
+                                + _character.gaitLift, _character.bodyDrift)
 
       BodyPart {
         id: _belly
@@ -1811,8 +2045,12 @@ BodyPartsGroup {
         // pose is not allowed to have happen to it while it is being held -
         // or while it is easing back to rest, which the gesture layer does
         // itself. holding covers both.
+        // A loaded move set owns the joints exactly as a held gesture does,
+        // and for longer: a knockdown handed to the idle pose stands back up
+        // within a fifth of a second.
         running: _character.activity == Character.Activity.Idle
                  && !_gestureAnim.holding
+                 && !_character.moveHolding
         loops: 1
     }
 
@@ -1865,8 +2103,10 @@ BodyPartsGroup {
     // first - immediately and without easing, since the cycle that is starting
     // animates from wherever it finds the joints anyway.
     onActivityChanged: {
-        if (_character.activity !== Character.Activity.Idle)
+        if (_character.activity !== Character.Activity.Idle) {
             _gestureAnim.drop()
+            _character.stopMove()
+        }
     }
 
     UseAnim {

--- a/plugins/clay_character3d/CharacterEditor.qml
+++ b/plugins/clay_character3d/CharacterEditor.qml
@@ -702,6 +702,89 @@ Item {
                     }
                 }
 
+                // Moves. A loadable set is what a character KNOWS rather than
+                // what it IS: it is loaded on demand, replaces whatever was
+                // loaded before it, and owns the whole body while it runs. That
+                // makes it the same kind of thing as a gesture and it sits here
+                // beside one, not beside the activity chips.
+                Rectangle { height: 1; color: root._panelLine; Layout.fillWidth: true }
+                Text { text: "Moves"; font.pixelSize: 12; font.bold: true; color: root._panelFg }
+                Flow {
+                    Layout.fillWidth: true
+                    spacing: 4
+                    Repeater {
+                        // Taken from the character's own map of shipped sets
+                        // rather than written out here, so a second set that
+                        // ships needs no edit in the editor.
+                        model: root.editTarget
+                             ? ["none"].concat(Object.keys(root.editTarget.shippedMoveSets))
+                             : ["none"]
+                        Chip {
+                            required property string modelData
+                            label: modelData
+                            active: root.editTarget !== null
+                                    && (root.editTarget.moveSet === modelData
+                                        || (modelData === "none"
+                                            && root.editTarget.moveSet === ""))
+                            onPicked: if (root.editTarget)
+                                          root.editTarget.moveSet =
+                                              modelData === "none" ? "" : modelData
+                        }
+                    }
+                }
+                Text {
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                    font.pixelSize: 9
+                    color: root._panelFgDim
+                    text: "A set is loaded on demand and is not part of every character. "
+                        + "Its moves run only while the activity is idle, so picking one "
+                        + "puts the activity back to idle."
+                }
+                Flow {
+                    Layout.fillWidth: true
+                    spacing: 4
+                    Repeater {
+                        model: root.editTarget ? root.editTarget.moves : []
+                        Chip {
+                            required property var modelData
+                            label: modelData.name
+                            active: root.editTarget !== null
+                                    && root.editTarget.activeMove === modelData.name
+                            onPicked: root.editTarget.playMove(modelData.name)
+                        }
+                    }
+                    // In the row rather than under it: a knockdown holds its
+                    // last frame on the floor on purpose, and letting go of it
+                    // belongs next to whatever started it.
+                    Chip {
+                        label: "stop"
+                        visible: root.editTarget !== null
+                                 && root.editTarget.moves.length > 0
+                        onPicked: if (root.editTarget) root.editTarget.stopMove()
+                    }
+                }
+                Text {
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                    font.pixelSize: 9
+                    color: root._panelFgDim
+                    // Which set is loaded, what it is doing with the body, and
+                    // whether that is still moving. The line that answers "I
+                    // clicked a move and it looks stuck": a knockdown holds its
+                    // last frame until something releases it.
+                    text: {
+                        const c = root.editTarget
+                        if (!c) return ""
+                        if (c.moveSet === "") return "no move set loaded"
+                        const set = c.moveSetName !== "" ? c.moveSetName : c.moveSet
+                        const move = c.activeMove !== "" ? c.activeMove : "idle"
+                        const how = c.movePlaying ? " (playing)"
+                                  : c.moveHolding ? " (holding)" : ""
+                        return set + " / " + move + how
+                    }
+                }
+
                 // Emotion: face AND walk, and it persists. This used to set the
                 // face alone (faceActivity), which left the walk unmoved and
                 // needed a second row for the gait's mood; one channel now.

--- a/plugins/clay_character3d/README.md
+++ b/plugins/clay_character3d/README.md
@@ -19,6 +19,8 @@ import Clayground.Character3D
 - **ParametricCharacter** - High-level parameters (bodyHeight, realism, maturity, femininity, mass) that auto-calculate dimensions
 - **RatioBasedCharacter** - Dimension ratios for fine-tuned proportion control
 - **CharacterEditor** - Visual editor overlay for character customization with persistence
+- **MoveSet** - A loadable set of named moves played onto one character, loaded on demand instead of carried by every character
+- **MartialArts** - The move set that ships with the plugin: fourteen moves from a stance to a knockdown and a get-up
 - **Speech** - Voice output (text-to-speech or wav/mp3) with approximate lip-sync
 - **ThoughtBubble** - Simple text bubble for speech/thought display
 
@@ -556,6 +558,39 @@ rotation on an upper arm carries a forward-pointing forearm OUTWARD on the
 right side, so `arm()` negates the yaw against the side. Written the other way
 round, the rear fist of the guard sat a head and a half outside the face and
 looked right in every sheet that had no reference to measure it against.
+
+### Loadable move sets
+
+Everything above is the basic set - what a character IS. Walking, running,
+standing, gazing, listening, gesturing, talking, working and boxing are wanted
+by every game, so they are always resident on every character. A move set is
+what a character KNOWS: a martial art, a dance, a trade's hand-work, wanted by
+one game and not the next, so it is loaded onto a character on demand, replaces
+whatever set was loaded before it, and is unloaded again by clearing
+`moveSet`. A set runs only while the activity is idle, exactly as a gesture
+does.
+
+```qml
+ParametricCharacter {
+    id: fighter
+    moveSet: "martial arts"          // or the URL of a MoveSet of your own
+    Component.onCompleted: fighter.playMove("stance")
+}
+```
+
+The shipped set offers fourteen moves: `stance`, `step`, `guard`, `jab`,
+`cross`, `uppercut` (standing), `lowGuard`, `sweep` (crouched), `frontKick`,
+`roundhouse` (kicks), `jumpPunch`, `jumpKick` (airborne), `knockdown`, `getUp`
+(ground). `knockdown` holds its last frame on the floor until `stopMove()` or
+another move releases it - which is what `getUp` starts from.
+
+What a set offers and what it is doing is readable from the character
+(`moves`, `moveSetName`, `activeMove`, `movePlaying`, `moveHolding`,
+`moveFinished`); see `Character`'s `moveSet` documentation for the whole API.
+`CharacterEditor` has a "Moves" section that loads a set and plays any of its
+moves, and `demo/Sandbox.qml` binds the same to the keyboard: `J` loads and
+unloads the set, `,` and `.` step through the moves, `V` plays the selected
+one and `B` stops.
 
 ### The gesture sheet
 

--- a/plugins/clay_character3d/animation/IdleAnim.qml
+++ b/plugins/clay_character3d/animation/IdleAnim.qml
@@ -62,6 +62,18 @@ ProceduralAnim {
             easing.type: Easing.InOutQuad
         }
 
+        // And back over its own feet: a move set's step, jump or stagger
+        // carries the body forward or back of the character's position, and
+        // a figure left standing off its own mark drifts a little further
+        // with every move played.
+        NumberAnimation {
+            duration: _idleAnim.duration
+            target: entity
+            property: "_heldDrift"
+            to: 0
+            easing.type: Easing.InOutQuad
+        }
+
         // Reset head and hip (e.g. tilted by UseAnim)
         HeadEulerAnim {
             duration: _idleAnim.duration

--- a/plugins/clay_character3d/animation/MoveSet.qml
+++ b/plugins/clay_character3d/animation/MoveSet.qml
@@ -1,0 +1,445 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+//
+// MoveSet - the animator behind a LOADABLE set of moves, as against the basic
+// set of animations every Character always carries.
+//
+// The difference is what each is for. Walking, running, standing, gazing,
+// listening, gesturing, talking, working and boxing are what a character IS -
+// every character in every game does them, so they are children of
+// Character.qml and cost what they cost. A martial art, a dance, a trade's
+// hand-work: those are what a character KNOWS, one game wants them and the
+// next does not, and there is no reason for a crowd of villagers to carry the
+// machinery for a spinning back kick. So a set is loaded onto a character by
+// name or by URL, replaces whatever set was loaded before it, and can be
+// unloaded again.
+//
+// A set brings its own model - Qt-free, node-checkable, exactly as gait.js
+// and action.js are - and this type is the replay machinery they share:
+//
+//   * ONE number is animated, the phase, and whatever the model answers for
+//     it is written onto the joints. The pose function is therefore the same
+//     one a sheet of stills or a unit suite reads, and cannot drift from what
+//     plays on screen.
+//   * A move is entered by BLENDING out of wherever the body actually is
+//     over blendMs, rather than by snapping to the move's first frame. A set
+//     is triggered from arbitrary states - mid-gesture, mid-stance, from
+//     another set's last pose - and a cut on every trigger is the one thing
+//     that makes a loadable set look bolted on.
+//   * A one-shot hands back to the set's own resting move when it ends
+//     (autoRest), unless the model marks it as one that HOLDS its last frame
+//     - which is how a knockdown stays on the floor for the get-up to start
+//     from.
+//
+// WHAT A SET DOES NOT DO is move the character across the floor. The model's
+// lift and drift move the BODY over its own feet, in leg heights, and both
+// return to zero by the end of a move; walking a character to where the kick
+// lands is the caller's business.
+
+import QtQuick
+
+/*!
+    \qmltype MoveSet
+    \inqmlmodule Clayground.Character3D
+    \inherits QtObject
+    \brief A loadable set of named moves, played onto one \l Character.
+
+    Sets are optional and are loaded on demand, unlike the basic animations
+    every character carries; see \l {Character::moveSet}{Character.moveSet},
+    which is the way one is normally loaded and the way it is given its
+    \l entity.
+
+    A set is this type plus a model: a Qt-free JavaScript library answering
+    \c {moves()}, \c {derive(move, opts)}, \c {poseAt(table, t)},
+    \c {mixPose(a, b, k)} and \c {restMove()}. \l MartialArts is the set that
+    ships with the plugin and the worked example of the shape.
+
+    \qml
+    // movesets/MartialArts.qml
+    import "../animation"
+    import "martialarts.js" as MA
+
+    MoveSet {
+        name: "martial arts"
+        model: ({ moves: MA.moves, derive: MA.derive, poseAt: MA.poseAt,
+                  mixPose: MA.mixPose, restMove: MA.restMove })
+    }
+    \endqml
+
+    \sa Character::moveSet, MartialArts, ActionCycleAnim
+*/
+QtObject {
+    id: _set
+
+    /*!
+        \qmlproperty var MoveSet::entity
+        \brief The \l Character whose joints this writes.
+
+        Set by \l Character when it loads the set; a set with no entity does
+        nothing rather than failing.
+    */
+    property var entity: null
+
+    /*!
+        \qmlproperty string MoveSet::name
+        \brief What the set is called, for a UI to show.
+    */
+    property string name: ""
+
+    /*!
+        \qmlproperty var MoveSet::model
+        \brief The set's pose model - the object answering \c {moves()},
+               \c {derive()}, \c {poseAt()}, \c {mixPose()} and
+               \c {restMove()}.
+    */
+    property var model: null
+
+    /*!
+        \qmlproperty real MoveSet::intensity
+        \brief How hard the moves are thrown, 0..1.
+
+        Speed and size, never a different pose - the same contract
+        \l {Character::actionIntensity}{actionIntensity} has, and it is fed
+        from there.
+    */
+    property real intensity: 0.5
+
+    /*!
+        \qmlproperty int MoveSet::blendMs
+        \brief How long a move takes to ease out of the pose the body was
+               already in, in milliseconds.
+
+        Zero cuts straight to the move's first frame.
+    */
+    property int blendMs: 140
+
+    /*!
+        \qmlproperty bool MoveSet::autoRest
+        \brief Whether a one-shot hands back to \l restMove when it ends.
+
+        On by default: a jab that leaves the body wherever the punch finished
+        reads as the animation stopping rather than as a punch being thrown.
+        A move the model marks as holding its last frame is exempt.
+    */
+    property bool autoRest: true
+
+    /*!
+        \qmlproperty var MoveSet::moves
+        \readonly
+        \brief What the set offers: a list of
+               \c {{name, label, group, loop, holds}}, in the model's own
+               order.
+    */
+    readonly property var moves: _set.model ? _set.model.moves() : []
+
+    /*!
+        \qmlproperty string MoveSet::restMove
+        \readonly
+        \brief The move a character in this set stands in when it is doing
+               nothing else, "" when the set names none.
+    */
+    readonly property string restMove: _set.model && _set.model.restMove
+                                     ? _set.model.restMove() : ""
+
+    /*!
+        \qmlproperty string MoveSet::move
+        \readonly
+        \brief The move being played, or the one whose last frame is being
+               held; "" when the set is idle.
+    */
+    readonly property string move: _set._move
+
+    /*!
+        \qmlproperty bool MoveSet::playing
+        \readonly
+        \brief True while a move is actually animating.
+    */
+    readonly property bool playing: _set._drive.running
+
+    /*!
+        \qmlproperty bool MoveSet::holding
+        \readonly
+        \brief True while the set owns the joints - playing a move, or sitting
+               on the last frame of one that holds.
+
+        What \l Character consults before it lets the idle pose take the body
+        back: a knockdown that is handed to the idle animation stands up
+        again within a fifth of a second.
+    */
+    readonly property bool holding: _set._drive.running || _set._held
+
+    /*!
+        \qmlproperty string MoveSet::handPose
+        \readonly
+        \brief What the current frame wants the hands to be doing, "" when the
+               set is idle - a fist through most of a fighting set, a flat
+               hand where one is planted on the floor.
+    */
+    readonly property string handPose: _set.holding ? _set._handPose : ""
+
+    /*!
+        \qmlproperty real MoveSet::phase
+        \brief Where in the move it is, 0..1. Set it with the animation
+               stopped to hold one frame.
+    */
+    property real phase: 0
+
+    /*!
+        \qmlsignal MoveSet::finished(string move)
+        \brief Emitted when a one-shot move reaches its end, before any
+               hand-back to \l restMove.
+    */
+    signal finished(string move)
+
+    /*!
+        \qmlmethod bool MoveSet::has(string move)
+        \brief Whether the set offers \a move.
+    */
+    function has(what) {
+        const m = _set.moves
+        for (let i = 0; i < m.length; ++i)
+            if (m[i].name === what)
+                return true
+        return false
+    }
+
+    /*!
+        \qmlmethod bool MoveSet::play(string move)
+        \brief Starts \a move, easing out of whatever the body is holding.
+               Returns false, and does nothing, when the set has no such move.
+    */
+    function play(what) {
+        if (!_set.model || !_set.entity || !_set.has(what))
+            return false
+        _set._drive.stop()
+        _set._blendAnim.stop()
+        // Where the body actually is, so the move can be entered from it.
+        _set._from = _set.blendMs > 0 ? _set._snapshot() : null
+        _set._blend = _set._from ? 0 : 1
+        _set._move = what
+        _set._held = false
+        _set._table = _set.model.derive(what, _set._opts())
+        _set.phase = 0
+        _set._drive.loops = _set._table.loop ? Animation.Infinite : 1
+        _set._drive.duration = Math.max(1, Math.round(_set._table.cycleMs))
+        _set._drive.start()
+        if (_set._from) {
+            _set._blendAnim.duration = _set.blendMs
+            _set._blendAnim.start()
+        }
+        _set._write()
+        return true
+    }
+
+    /*!
+        \qmlmethod void MoveSet::stop()
+        \brief Stops whatever is playing and lets go of the joints, which stay
+               where the last frame left them.
+    */
+    function stop() {
+        _set._drive.stop()
+        _set._blendAnim.stop()
+        _set._move = ""
+        _set._held = false
+        _set._table = null
+        _set._from = null
+        _set._blend = 1
+    }
+
+    /*!
+        \qmlmethod var MoveSet::tableFor(string move)
+        \brief The derived numbers \a move is replayed from at this set's
+               \l intensity and this character's build - its \c cycleMs among
+               them. Null when the set has no such move.
+    */
+    function tableFor(what) {
+        return _set.model && _set.has(what)
+             ? _set.model.derive(what, _set._opts()) : null
+    }
+
+    /*!
+        \qmlmethod var MoveSet::poseAt(string move, real t)
+        \brief The joint angles \a move holds at phase \a t, 0..1, with
+               nothing running.
+
+        Pure, and the same answer the running move gives at that moment - this
+        type plays this very function. The wrist roll comes back as a fraction
+        of a quarter turn; the degrees are the character's.
+    */
+    function poseAt(what, t) {
+        const table = _set.tableFor(what)
+        return table === null ? null : _set.model.poseAt(table, t)
+    }
+
+    /*!
+        \qmlmethod void MoveSet::apply(string move, real t)
+        \brief Freezes the joints at phase \a t of \a move, running or not.
+
+        For looking, not for playing: a row of characters frozen at successive
+        phases is the move on one sheet.
+    */
+    function apply(what, t) {
+        const p = _set.poseAt(what, t)
+        if (p !== null)
+            _set._writePose(p)
+    }
+
+    // --- the machinery --------------------------------------------------------
+
+    property string _move: ""
+    property bool _held: false
+    property var _table: null
+    property var _from: null
+    property real _blend: 1
+    property string _handPose: ""
+
+    function _opts() {
+        const c = _set.entity
+        return {
+            intensity: _set.intensity,
+            // The body, so a fall lands on the floor of THIS figure: the
+            // model drops the waist by whatever the waist stands at, and a
+            // tall character's waist stands higher than a short one's.
+            legHeight: c ? c.legHeight : 0,
+            hipHeight: c ? c.hipHeight : 0,
+            footHeight: c ? c.footHeight : 0,
+            torsoDepth: c ? c.torsoDepth : 0
+        }
+    }
+
+    // The phase is written every frame while a move runs, so that is the one
+    // hook needed: play() writes the first frame itself, and nothing else
+    // changes the table while a move is in flight.
+    onPhaseChanged: _set._write()
+
+    function _write() {
+        if (!_set._table || !_set.model)
+            return
+        let p = _set.model.poseAt(_set._table, _set.phase)
+        if (_set._blend < 1 && _set._from)
+            p = _set.model.mixPose(_set._from, p, _set._blend)
+        _set._writePose(p)
+    }
+
+    function _writePose(p) {
+        const c = _set.entity
+        if (!c || !c.rightArm || !c.head)
+            return
+        const roll = c.handRestRoll === undefined ? 90 : c.handRestRoll
+
+        function limb(m, a) {
+            m.upperArm.eulerRotation = Qt.vector3d(a.upper[0], a.upper[1], a.upper[2])
+            m.lowerArm.eulerRotation = Qt.vector3d(a.lower[0], a.lower[1], a.lower[2])
+            // The roll arrives as a fraction of a quarter turn; the degrees
+            // are the character's, not the move's.
+            m.hand.eulerRotation = Qt.vector3d(a.hand[0], a.hand[1] / 90 * roll, a.hand[2])
+        }
+        function foot(l, a) {
+            l.upperLeg.eulerRotation = Qt.vector3d(a.upper[0], a.upper[1], a.upper[2])
+            l.lowerLeg.eulerRotation = Qt.vector3d(a.lower[0], a.lower[1], a.lower[2])
+            l.foot.eulerRotation = Qt.vector3d(a.foot[0], a.foot[1], a.foot[2])
+        }
+        limb(c.rightArm, p.rightArm)
+        limb(c.leftArm, p.leftArm)
+        foot(c.rightLeg, p.rightLeg)
+        foot(c.leftLeg, p.leftLeg)
+        c.hip.eulerRotation = Qt.vector3d(p.hip[0], p.hip[1], p.hip[2])
+        c.torso.eulerRotation = Qt.vector3d(p.torso[0], p.torso[1], p.torso[2])
+        c.belly.eulerRotation = Qt.vector3d(p.belly[0], p.belly[1], p.belly[2])
+        c.chest.eulerRotation = Qt.vector3d(p.chest[0], p.chest[1], p.chest[2])
+        c.head.poseEuler = Qt.vector3d(p.head[0], p.head[1], p.head[2])
+        // The body over its own feet, in leg heights, through the same two
+        // slots the gait uses. IdleAnim eases both back to zero afterwards.
+        if (p.lift !== undefined && c._heldLift !== undefined)
+            c._heldLift = p.lift * c.legHeight
+        if (p.drift !== undefined && c._heldDrift !== undefined)
+            c._heldDrift = p.drift * c.legHeight
+        _set._handPose = p.hand === undefined ? "" : p.hand
+    }
+
+    // Where the body is right now, in the shape the model's poses come in, so
+    // a move can be eased out of it. Read from the joints rather than
+    // remembered: what was holding them may have been a gait, a gesture, or
+    // another set entirely.
+    function _snapshot() {
+        const c = _set.entity
+        if (!c || !c.rightArm || !c.head)
+            return null
+        const roll = c.handRestRoll === undefined || c.handRestRoll === 0
+                   ? 90 : c.handRestRoll
+        function limb(m) {
+            return { upper: [m.upperArm.eulerRotation.x, m.upperArm.eulerRotation.y,
+                             m.upperArm.eulerRotation.z],
+                     lower: [m.lowerArm.eulerRotation.x, m.lowerArm.eulerRotation.y,
+                             m.lowerArm.eulerRotation.z],
+                     // Back into the fraction of a quarter turn the model
+                     // speaks, so the two ends of the blend are the same unit.
+                     hand: [m.hand.eulerRotation.x, m.hand.eulerRotation.y / roll * 90,
+                            m.hand.eulerRotation.z] }
+        }
+        function foot(l) {
+            return { upper: [l.upperLeg.eulerRotation.x, l.upperLeg.eulerRotation.y,
+                             l.upperLeg.eulerRotation.z],
+                     lower: [l.lowerLeg.eulerRotation.x, l.lowerLeg.eulerRotation.y,
+                             l.lowerLeg.eulerRotation.z],
+                     foot: [l.foot.eulerRotation.x, l.foot.eulerRotation.y,
+                            l.foot.eulerRotation.z] }
+        }
+        function v3(v) { return [v.x, v.y, v.z] }
+        const leg = c.legHeight > 0 ? c.legHeight : 1
+        return {
+            rightArm: limb(c.rightArm), leftArm: limb(c.leftArm),
+            rightLeg: foot(c.rightLeg), leftLeg: foot(c.leftLeg),
+            hip: v3(c.hip.eulerRotation),
+            torso: v3(c.torso.eulerRotation),
+            belly: v3(c.belly.eulerRotation),
+            chest: v3(c.chest.eulerRotation),
+            head: v3(c.head.poseEuler),
+            lift: c.gaitLift / leg,
+            drift: c.bodyDrift / leg,
+            hand: c.handPose
+        }
+    }
+
+    // A one-shot has reached its end. Either it holds its last frame - the
+    // knockdown - or the set stands back up in its resting move.
+    function _done() {
+        const what = _set._move
+        if (_set._table && _set._table.holds) {
+            _set._held = true
+            _set.finished(what)
+            return
+        }
+        _set.finished(what)
+        // finished() may itself have started something; only fall back to the
+        // rest move when nothing else has taken over.
+        if (_set._drive.running || _set._move !== what)
+            return
+        if (_set.autoRest && _set.restMove !== "" && _set.restMove !== what)
+            _set.play(_set.restMove)
+        else
+            _set.stop()
+    }
+
+    // The phase is driven linearly: the SHAPE of a move lives in the model's
+    // keys and the curves they arrive on, and easing the phase instead would
+    // ease every joint by the same curve - which is the whole difference
+    // between a jab and a step.
+    property NumberAnimation _drive: NumberAnimation {
+        target: _set
+        property: "phase"
+        from: 0
+        to: 1
+        duration: 500
+        easing.type: Easing.Linear
+        onFinished: _set._done()
+    }
+
+    property NumberAnimation _blendAnim: NumberAnimation {
+        target: _set
+        property: "_blend"
+        from: 0
+        to: 1
+        duration: 140
+        easing.type: Easing.InOutQuad
+    }
+}

--- a/plugins/clay_character3d/bench/MoveSheetSandbox.qml
+++ b/plugins/clay_character3d/bench/MoveSheetSandbox.qml
@@ -1,0 +1,397 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+// @brief Every move of a loadable move set side by side, one frozen figure each
+// @tags 3D, Character, Animation, MoveSet, Martial Arts
+// @category Plugin Benches
+//
+// MoveSheetSandbox - a loadable move set the way GestureSheetSandbox shows the
+// gestures and GaitSheetSandbox shows a walk: all of it at once, same figure,
+// same light, same angle, labelled, and NOTHING MOVING.
+//
+// The SET is what is being judged, not any one move. A kick looked at on its
+// own is looked at against a memory of the last one, and a memory grades
+// generously - which is how a "high" roundhouse that never got the foot past
+// the hip survived being watched a dozen times. Side by side against a jab,
+// a front kick and a stance, the question "is this move the thing its name
+// says" is one the sheet answers in a single frame.
+//
+//   claydojo --sbx plugins/clay_character3d/bench/MoveSheetSandbox.qml
+//
+//   clayrender plugins/clay_character3d/bench/MoveSheetSandbox.qml \
+//       --size 2600x760 --wait-for 'ready' --out /tmp/moves.png
+//
+// TWO SHEETS, one component. With `move` empty it draws the SET - one column
+// per move, each frozen at the phase it is meant to be read at. With `move`
+// set to one of the names it draws that move as a strip of phases, which is
+// how a move's TIMING is judged rather than its peak:
+//
+//   clayrender plugins/clay_character3d/bench/MoveSheetSandbox.qml \
+//       --size 2600x700 --set 'move="roundhouse"' --set 'frames=10' \
+//       --wait-for 'ready' --out /tmp/roundhouse.png
+//
+// EVERY POSE HERE IS FROZEN AND DETERMINISTIC. The columns come from
+// Character.applyMovePose(), the pure pose model in the set's own JavaScript -
+// the same function MoveSet plays - so the sheet cannot show a stance the
+// shipped move does not have.
+//
+// HOW TO READ IT. Two questions, in this order. First: can a stranger name
+// each column from its SILHOUETTE alone? `silhouette=true` takes the lighting
+// and the colour away and leaves exactly that. Second: is every figure ON the
+// floor? The floor slab's top face is y = 0 and each column stands on it, so
+// a crouch that sinks or a stance that floats is visible as a gap, and both
+// were real while this set was being written.
+
+import QtQuick
+import QtQuick3D
+import Clayground.Canvas3D
+import Clayground.Character3D
+
+pragma ComponentBehavior: Bound
+
+Item {
+    id: root
+    anchors.fill: parent
+    focus: true
+
+    /*! Which set is on the sheet. Any name Character::moveSet accepts. */
+    property string set: "martial arts"
+
+    /*!
+        Empty for the set sheet; a move's name to draw that one move as a strip
+        of \l frames phases instead.
+    */
+    property string move: ""
+
+    /*! How many phases the strip freezes, evenly spaced over the whole move. */
+    property int frames: 10
+
+    /*! How hard the moves are thrown, 0..1. Size and speed, never the pose. */
+    property real intensity: 0.5
+
+    /*!
+        Where each move is worth freezing: the moment it is meant to be read
+        at, which is its peak for a strike and its settled frame for a stance.
+        Anything the set offers and this does not name is read at its midpoint.
+    */
+    readonly property var readAt: ({
+        stance: 0.0, step: 0.34, guard: 0.45, jab: 0.48, cross: 0.52,
+        uppercut: 0.54, lowGuard: 0.5, sweep: 0.58, frontKick: 0.54,
+        roundhouse: 0.6, jumpPunch: 0.5, jumpKick: 0.52,
+        knockdown: 1.0, getUp: 0.64
+    })
+
+    /*! How the figures are turned: 0 head-on, 35 three-quarter, 90 side-on. */
+    property real yaw: 35
+
+    /*! How far the camera is lifted, in degrees. The floor drops past 60. */
+    property real pitch: 0
+
+    /*! Flat ink on everything, no lights, no floor: the outline alone. */
+    property bool silhouette: false
+
+    /*! Shrink every figure in place, for the small-on-screen read. */
+    property real scale: 1.0
+
+    property real bodyHeight: 10
+
+    // --- driving it -----------------------------------------------------------
+
+    function show(what) { root.move = (what === undefined ? "" : what) }
+    function sheet() { root.move = "" }
+    function setYaw(deg) { root.yaw = deg }
+
+    readonly property bool strip: root.move !== ""
+
+    // Read from the PROBE and never from the row of figures: the row's length
+    // is what this answers, so a name list that asked the row would be asking
+    // its own answer - which QML reports as a binding loop and clayrender
+    // turns into a non-zero exit.
+    readonly property var names: {
+        let out = []
+        for (let i = 0; i < _probe.moves.length; ++i)
+            out.push(_probe.moves[i].name)
+        return out
+    }
+    readonly property int count: root.strip ? root.frames
+                                            : Math.max(1, root.names.length)
+
+    /*!
+        How many figures have taken their pose. Wait for \l ready: a --set
+        lands whenever clayrender has finished loading, which can be after
+        ready was already true once, so the tally is cleared on every change
+        and the capture waits for the new one.
+    */
+    property int posed: 0
+    readonly property bool ready: root.count > 0 && root.posed >= root.count
+
+    property int _generation: 0
+    function invalidate() {
+        root.posed = 0
+        for (let i = 0; i < _figures.count; ++i) {
+            const f = _figures.objectAt(i)
+            if (f) f.counted = false
+        }
+        root._generation++
+    }
+    onMoveChanged: root.invalidate()
+    onIntensityChanged: root.invalidate()
+    onFramesChanged: root.posed = 0
+
+    property int _layout: 0
+    onWidthChanged: root._layout++
+    onHeightChanged: root._layout++
+
+    readonly property real _pitchPx: {
+        root._layout
+        const a = v3d.mapFrom3DScene(Qt.vector3d(0, 0, 0))
+        const b = v3d.mapFrom3DScene(Qt.vector3d(root._spacing, 0, 0))
+        return Math.abs(b.x - a.x)
+    }
+
+    /*!
+        One line for the header and for --eval to read back: what is drawn, and
+        the numbers behind the poses that a picture cannot state. The floor
+        figure is the one worth having - "every foot is on the ground" is a
+        claim about a number, and a picture of a foot near a line is not.
+    */
+    function report() {
+        let s = (root.strip ? root.move + ", " + root.frames + " frames"
+                            : root.set + ", " + root.names.length + " moves")
+              + "  yaw " + root.yaw.toFixed(0) + " pitch " + root.pitch.toFixed(0)
+              + "  effort " + root.intensity.toFixed(2)
+              + "  x" + root.scale.toFixed(2)
+              + (root.silhouette ? "  SILHOUETTE" : "")
+        if (!root.strip && root.names.length > 0) {
+            const g = _probe.movePoseAt("stance", 0)
+            const k = _probe.movePoseAt("frontKick", root.readAt.frontKick)
+            if (g && k)
+                s += "  |  stance blade " + g.torso[1].toFixed(0)
+                   + " lift " + g.lift.toFixed(2)
+                   + "  |  front kick hip " + k.rightLeg.upper[0].toFixed(0)
+                   + " knee " + k.rightLeg.lower[0].toFixed(0)
+        }
+        return s
+    }
+
+    readonly property real _spacing: root.bodyHeight * 0.9
+    readonly property real _span: root._spacing * root.count
+
+    // A character that is never drawn, purely so the sheet can ask the set
+    // what it contains before the row of figures exists - the row's length is
+    // the answer, so it cannot be the thing that answers.
+    Item {
+        ParametricCharacter { id: _probe; visible: false; moveSet: root.set }
+    }
+
+    // --- the scene ------------------------------------------------------------
+
+    View3D {
+        id: v3d
+        anchors.fill: parent
+        camera: cam
+
+        environment: SceneEnvironment {
+            clearColor: "#f4f2ed"
+            backgroundMode: SceneEnvironment.Color
+            antialiasingMode: SceneEnvironment.MSAA
+            antialiasingQuality: SceneEnvironment.High
+        }
+
+        DirectionalLight {
+            eulerRotation.x: -35
+            eulerRotation.y: -30
+            brightness: root.silhouette ? 0.0 : 0.9
+            ambientColor: root.silhouette ? Qt.rgba(1, 1, 1, 1)
+                                          : Qt.rgba(0.55, 0.55, 0.6, 1.0)
+        }
+        DirectionalLight {
+            eulerRotation.x: -15
+            eulerRotation.y: 160
+            visible: !root.silhouette
+            brightness: 0.4
+        }
+
+        // Orthographic: the figures along X map linearly to the screen, so a
+        // label sits under its own figure and two columns are the same size
+        // whatever they are doing.
+        OrthographicCamera {
+            id: cam
+            readonly property real _r: Math.PI / 180 * root.pitch
+            position: Qt.vector3d(root._span * 0.5 - root._spacing * 0.5,
+                                  root.bodyHeight * 0.5 + 200 * Math.sin(cam._r),
+                                  200 * Math.cos(cam._r))
+            eulerRotation: Qt.vector3d(-root.pitch, 0, 0)
+            horizontalMagnification: Math.max(0.01, v3d.width) / (root._span * 1.05)
+            verticalMagnification: horizontalMagnification
+            clipNear: 1
+            clipFar: 400
+        }
+
+        // The floor: a slab whose top face is y = 0, so every figure stands on
+        // one line and a crouch that sinks into it is visible as such.
+        Box3D {
+            visible: !root.silhouette && root.pitch < 60
+            position: Qt.vector3d(root._span * 0.5 - root._spacing * 0.5, -0.3, 0)
+            width: root._span * 1.1
+            height: 0.6
+            depth: root.bodyHeight * 1.5
+            color: "#d7d3ca"
+            showEdges: true
+            edgeColorFactor: 0.7
+        }
+
+        Repeater3D {
+            id: _figures
+            model: root.count
+
+            ParametricCharacter {
+                id: figure
+                required property int index
+
+                readonly property string what: root.strip ? root.move
+                    : (root.names.length > index ? root.names[index] : "")
+                readonly property real at: root.strip
+                    ? figure.index / Math.max(1, root.frames - 1)
+                    : (root.readAt[figure.what] === undefined
+                       ? 0.5 : root.readAt[figure.what])
+
+                position: Qt.vector3d(index * root._spacing, 0, 0)
+                eulerRotation: Qt.vector3d(0, root.yaw, 0)
+                scale: Qt.vector3d(root.scale, root.scale, root.scale)
+
+                moveSet: root.set
+                bodyHeight: root.bodyHeight
+                realism: 0.3
+                roundness: 0.15
+                detail: Character.Detail.High
+                autoBlink: false
+                gazeBehaviour: false
+                activity: Character.Activity.Idle
+                actionIntensity: root.intensity
+
+                skin: root.silhouette ? "#1b1b1f" : "#e8beac"
+                topClothing: root.silhouette ? "#1b1b1f" : "#b8453a"
+                bottomClothing: root.silhouette ? "#1b1b1f" : "#2f3d52"
+                footColor: root.silhouette ? "#1b1b1f" : "#4a3728"
+                hairTone: root.silhouette ? "#1b1b1f" : "#2b2119"
+                eyeTone: root.silhouette ? "#1b1b1f" : "#4a3728"
+
+                // The hands are not written by applyMovePose - they are
+                // handPose's - so the sheet asks the model what the move wants
+                // and sets it, exactly as the gesture sheet does for an
+                // action. Without it a sweep plants a fist on the floor.
+                function pose() {
+                    if (figure.what === "")
+                        return
+                    const p = figure.movePoseAt(figure.what, figure.at)
+                    if (p === null)
+                        return
+                    figure.handPose = p.hand
+                    figure.applyMovePose(figure.what, figure.at)
+                }
+
+                property bool counted: false
+                function take() {
+                    figure.pose()
+                    if (figure.counted)
+                        return
+                    figure.counted = true
+                    root.posed++
+                }
+
+                // The first pose waits out IdleAnim's 200 ms: it zeroes what
+                // it does not own, and a pose written inside that window is
+                // animated away under the capture.
+                Timer {
+                    id: _first
+                    interval: 300
+                    onTriggered: figure.take()
+                }
+                Component.onCompleted: _first.start()
+
+                Connections {
+                    target: root
+                    function on_GenerationChanged() { figure.take() }
+                }
+            }
+        }
+    }
+
+    // --- the labels -----------------------------------------------------------
+
+    Repeater {
+        model: root.count
+        Text {
+            id: _label
+            required property int index
+            readonly property point at: {
+                root._layout
+                const p = v3d.mapFrom3DScene(Qt.vector3d(index * root._spacing, -1.2, 0))
+                return Qt.point(p.x, p.y)
+            }
+            x: at.x - width / 2
+            y: at.y + 4
+            width: Math.max(40, root._pitchPx - 6)
+            horizontalAlignment: Text.AlignHCenter
+            elide: Text.ElideRight
+            font.family: _header.font.family
+            font.pixelSize: Math.max(8, Math.min(13, root._pitchPx / 9))
+            color: "#4a4a50"
+            text: root.strip
+                ? "t=" + (index / Math.max(1, root.frames - 1)).toFixed(2)
+                : (root.names.length > index ? root.names[index] : "")
+        }
+    }
+
+    Rectangle {
+        x: 0; y: 0
+        width: _header.implicitWidth + 20
+        height: _header.implicitHeight + 12
+        color: Qt.rgba(1, 1, 1, 0.85)
+        visible: !root.silhouette
+    }
+    Text {
+        id: _header
+        x: 10; y: 6
+        // No font.family: "monospace" resolves to nothing on macOS and Qt
+        // warns about it once, which is enough to make clayrender exit 2 on a
+        // bench that is perfectly fine.
+        font.family: Qt.platform.os === "osx" ? "Menlo"
+                   : Qt.platform.os === "windows" ? "Consolas" : "monospace"
+        font.pixelSize: 13
+        color: "#1b1b1f"
+        visible: !root.silhouette
+        text: root.report()
+        Timer { interval: 400; running: true; repeat: true; onTriggered: _header.text = root.report() }
+    }
+
+    Text {
+        x: 10
+        y: root.height - implicitHeight - 8
+        font.family: _header.font.family
+        font.pixelSize: 11
+        color: "#6b6b72"
+        visible: !root.silhouette
+        text: "0 the set   1..9 one move as a strip   left/right turn   w/s camera up/down   "
+            + "up/down frames   h silhouette   -/+ scale"
+    }
+
+    Keys.onPressed: (e) => {
+        if (e.key === Qt.Key_0) root.sheet()
+        else if (e.key >= Qt.Key_1 && e.key <= Qt.Key_9) {
+            const i = e.key - Qt.Key_1
+            if (i < root.names.length) root.show(root.names[i])
+        }
+        else if (e.key === Qt.Key_Left) root.yaw -= 15
+        else if (e.key === Qt.Key_Right) root.yaw += 15
+        else if (e.key === Qt.Key_W) root.pitch = Math.min(80, root.pitch + 10)
+        else if (e.key === Qt.Key_S) root.pitch = Math.max(0, root.pitch - 10)
+        else if (e.key === Qt.Key_Up) root.frames = Math.min(24, root.frames + 1)
+        else if (e.key === Qt.Key_Down) root.frames = Math.max(2, root.frames - 1)
+        else if (e.key === Qt.Key_H) root.silhouette = !root.silhouette
+        else if (e.key === Qt.Key_Minus) root.scale = Math.max(0.2, root.scale - 0.1)
+        else if (e.key === Qt.Key_Plus || e.key === Qt.Key_Equal)
+            root.scale = Math.min(1.5, root.scale + 0.1)
+        else return
+        e.accepted = true
+    }
+}

--- a/plugins/clay_character3d/demo/Sandbox.qml
+++ b/plugins/clay_character3d/demo/Sandbox.qml
@@ -54,6 +54,23 @@ Item {
     // All characters for editor
     readonly property var allCharacters: [character, npcThinker, npcEater, npcHero, npcChild, npcStylized]
 
+    // The player character's loadable move set, driven from the keyboard so a
+    // set can be loaded and every move it offers triggered without opening the
+    // editor panel. Nothing loads a set at startup: a set is what a character
+    // KNOWS rather than what it is, and loading one should be something a
+    // person does and watches happen.
+    property int moveIndex: 0
+    readonly property var selectedMove:
+        character.moves.length > 0
+      ? character.moves[Math.min(root.moveIndex, character.moves.length - 1)]
+      : null
+    function stepMove(dir) {
+        const n = character.moves.length
+        if (n === 0)
+            return
+        root.moveIndex = (root.moveIndex + dir + n) % n
+    }
+
     // Forward keys to game controller for WASD movement
     Keys.forwardTo: [gameController]
 
@@ -131,6 +148,32 @@ Item {
             event.accepted = true
         } else if (event.key === Qt.Key_0) {
             gesturer.setEmotion("")
+            event.accepted = true
+        }
+        // The loadable move set on the player character. Loading it is a
+        // toggle, because unloading is the other half of what "on demand"
+        // means and there is nothing else to see it with.
+        else if (event.key === Qt.Key_J) {
+            character.moveSet = character.moveSet === "" ? "martial arts" : ""
+            root.moveIndex = 0
+            event.accepted = true
+        }
+        // The set names its own moves, so the keyboard walks the list the set
+        // offers rather than binding a key per move.
+        else if (event.key === Qt.Key_Comma) {
+            root.stepMove(-1)
+            event.accepted = true
+        } else if (event.key === Qt.Key_Period) {
+            root.stepMove(1)
+            event.accepted = true
+        } else if (event.key === Qt.Key_V) {
+            if (root.selectedMove !== null)
+                character.playMove(root.selectedMove.name)
+            event.accepted = true
+        } else if (event.key === Qt.Key_B) {
+            // A move that holds its last frame - the knockdown lying on the
+            // floor - stays there until something lets go of the joints.
+            character.stopMove()
             event.accepted = true
         }
         // Let other keys pass through to forwardTo targets
@@ -532,6 +575,7 @@ Item {
     // Gesture keys, and what the layer says it is doing - the state a test
     // asserts on rather than watching the arm.
     Rectangle {
+        id: gestureHelpPanel
         anchors.bottom: gameController.top
         anchors.left: parent.left
         anchors.margins: 10
@@ -566,6 +610,52 @@ Item {
                       + "  settled " + gesturer.gestureSettled + "  emotion \"" + gesturer.emotion + "\""
                 font.pixelSize: 11
                 color: _gesturePal.windowText
+            }
+        }
+    }
+
+    // The move set on the player character, above the gesture panel because it
+    // is the same kind of thing on the other figure. The status line is there
+    // because a move that holds its last frame - the knockdown on the floor -
+    // is indistinguishable from a stalled animation without it.
+    Rectangle {
+        anchors.bottom: gestureHelpPanel.top
+        anchors.left: parent.left
+        anchors.margins: 10
+        width: moveHelp.width + 20
+        height: moveHelp.height + 16
+        color: _movePal.window
+        opacity: 0.9
+        radius: 8
+        border.color: Qt.alpha(_movePal.windowText, 0.2)
+
+        SystemPalette { id: _movePal }
+
+        Column {
+            id: moveHelp
+            anchors.centerIn: parent
+            spacing: 2
+
+            Text {
+                text: "Move set (Player, parametric Character)"
+                font.bold: true
+                font.pixelSize: 11
+                color: _movePal.windowText
+            }
+            Text {
+                text: "J load / unload martial arts  , . previous / next move\n"
+                      + "V play the selected move  B stop (releases a held one)"
+                font.pixelSize: 11
+                color: _movePal.windowText
+            }
+            Text {
+                text: "set \"" + (character.moveSet === "" ? "no set" : character.moveSetName) + "\""
+                      + "  selected \"" + (root.selectedMove ? root.selectedMove.name : "-") + "\""
+                      + "  active \"" + character.activeMove + "\""
+                      + (character.movePlaying ? " playing"
+                         : character.moveHolding ? " holding" : "")
+                font.pixelSize: 11
+                color: _movePal.windowText
             }
         }
     }

--- a/plugins/clay_character3d/movesets/MartialArts.qml
+++ b/plugins/clay_character3d/movesets/MartialArts.qml
@@ -1,0 +1,44 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+import QtQuick
+import "../animation"
+import "martialarts.js" as MA
+
+/*!
+    \qmltype MartialArts
+    \inqmlmodule Clayground.Character3D
+    \inherits MoveSet
+    \brief The martial-arts move set: fourteen moves, from the neutral stance
+           to a knockdown and back up off the floor.
+
+    A loadable set, not part of the basic animations every \l Character
+    carries - load it with \c {character.moveSet = "martial arts"} and play a
+    move with \c {character.playMove("roundhouse")}:
+
+    \list
+    \li standing - \c stance, \c step, \c guard, \c jab, \c cross,
+        \c uppercut
+    \li crouched - \c lowGuard, \c sweep
+    \li kicks - \c frontKick, \c roundhouse
+    \li airborne - \c jumpPunch, \c jumpKick
+    \li ground - \c knockdown, \c getUp
+    \endlist
+
+    Orthodox throughout: the left side leads and jabs, the right is the rear
+    and throws the cross, the uppercut and every kick. \c stance is the
+    resting move, so a one-shot hands back to it; \c knockdown is the one move
+    that does not - it holds the figure on the floor, which is where \c getUp
+    starts.
+
+    It ships \e beside \l FightAnim rather than replacing it: that is the
+    basic set's boxing loop, this is a set a character is given.
+
+    Every angle is in \c {martialarts.js}, which is Qt-free and checked by
+    \c {node martialarts.test.js}.
+
+    \sa MoveSet, Character::moveSet, FightAnim
+*/
+MoveSet {
+    name: "martial arts"
+    model: ({ moves: MA.moves, derive: MA.derive, poseAt: MA.poseAt,
+              mixPose: MA.mixPose, restMove: MA.restMove })
+}

--- a/plugins/clay_character3d/movesets/martialarts.js
+++ b/plugins/clay_character3d/movesets/martialarts.js
@@ -1,0 +1,889 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+//
+// The martial-arts move set: the fourteen moves of the reference sheet
+// (#238), as poses rather than as animations.
+//
+// Qt-free on purpose (.pragma library, no engine, no clock, no randomness),
+// for the same reason gait.js and action.js are: `node martialarts.test.js`
+// checks the poses in a second, and "a front kick puts the foot above the
+// hip" is then an exact assertion on numbers rather than an impression from
+// a screenshot.
+//
+// HOW A MOVE IS WRITTEN HERE. Not as a curve per joint - that is what the
+// boxing cycle in action.js does, and it is the right shape for one cycle
+// authored once. A SET is a different problem: fourteen moves, and more
+// later, each of which has to start and end somewhere the next one can pick
+// up from. So a move here is a short list of KEY FRAMES, each frame a flat
+// object of named angles, and poseAt() mixes the two frames around the phase
+// it is asked for. Three things fall out of that:
+//
+//   * a move whose first and last key are the ready stance returns to the
+//     stance by construction, so any two moves chain and any loop loops;
+//   * effort scales a move by mixing its keys toward the stance, which
+//     changes the size of a move and never its shape;
+//   * the knockdown can END lying down and the get-up START there, simply by
+//     sharing that frame - which is what "13. KNOCKDOWN" and "14. GET-UP"
+//     are on the sheet.
+//
+// SIGNS. The frame is written in HUMAN terms - "the upper arm is 32 degrees
+// forward of hanging", "the knee is flexed 26 degrees" - and finish() is the
+// one place that turns those into the joints' own conventions, which are
+// action.js's and are the opposite way round:
+//
+//   * upper/lower arm and leg x: NEGATIVE pitches the limb forward.
+//   * upper arm/leg z: positive carries the limb OUT from the centre line on
+//     the +X (right) side; frames are written unsigned and mirrored at use.
+//   * hand y: the wrist roll about the forearm, as a FRACTION of a quarter
+//     turn - the degrees are the character's (handRestRoll), not the move's.
+//   * foot y: turns the foot on its ball. NOT mirrored - a positive turn
+//     takes either foot's toes toward +X, which is out on the right foot and
+//     in on the left.
+//   * head x: positive looks DOWN.
+//   * the arm/leg direction that matters for a strike is upper + elbow:
+//     0 is straight down, 90 forward and level, 180 straight up.
+//
+// LEAD AND REAR are the orthodox pair: the LEFT side leads (it is the side
+// turned toward the opponent and the side that jabs), the RIGHT is the rear
+// and throws the cross, the uppercut and every kick here.
+//
+// MOVES ARE IN PLACE. lift and drift move the BODY over its own feet, in leg
+// heights, and both come back to zero by the end of a move; carrying the
+// character across the floor is the caller's business, not the set's.
+
+.pragma library
+
+// --- the ready stance ---------------------------------------------------------
+//
+// Frame 1 of the sheet, and the frame every other move on it is written
+// against. Wider, lower and less bladed than the boxing guard in action.js:
+// a boxer stands on the balls of both feet to move, and this stance is a
+// platform to kick from, so the feet are further apart, the knees are
+// further bent and the rear foot is turned out rather than trailing.
+var STANCE = {
+    // The trunk. The blade turns the lead shoulder toward the opponent and
+    // carries the hips and the legs with it - that is what a stance is.
+    blade: 28,
+    lean: 8,          // the chest forward over the guard
+    headPitch: 7,     // chin down, looking through the brows
+    headTurn: 0.7,    // how much of the blade the face turns back
+
+    // The guard. The lead hand is further out and lower than the rear, which
+    // is tucked at the jaw: a guard whose two fists are a mirror pair reads
+    // as a pose, one whose two are different reads as a person.
+    leadUp: 32, leadOut: 15, leadIn: 16, leadElbow: 112, leadRoll: 0.7,
+    rearUp: 42, rearOut: 6,  rearIn: 36, rearElbow: 128, rearRoll: 0.9,
+    wrist: 0,
+
+    // The feet: a long stance, both knees bent, the rear heel a little up
+    // and the rear foot turned out to push from.
+    leadLegUp: 26, leadKnee: 26, leadToe: 0,  leadPivot: 0,
+    rearLegUp: -20, rearKnee: 22, rearToe: 12, rearPivot: 30,
+    legOut: 12,
+
+    hand: "fist"
+}
+
+// How far below its standing height the figure sits on a leg folded like
+// this, in leg heights: a bent leg is a shorter leg, and without this every
+// crouch in the set would leave the feet hanging under the floor.
+//
+// The foot is followed through the joints rather than approximated by the
+// two pitches: the leg is also carried \a out to the side, and the sheet's
+// stances are wide enough that ignoring that puts a deep crouch a tenth of a
+// leg into the ground. The rotations are the joints' own, in the order the
+// engine applies them - Z, then X, then Y.
+function plant(legUp, knee, out) {
+    var rad = Math.PI / 180
+    out = out === undefined ? STANCE.legOut : out
+    var co = Math.cos(out * rad)
+    var cu = Math.cos(legUp * rad), su = Math.sin(legUp * rad)
+    var ck = Math.cos(knee * rad), sk = Math.sin(knee * rad)
+    // The thigh, straight down then swung \a out then pitched \a legUp
+    // forward; and the shin, which carries all of that plus its own flexion.
+    // Only the vertical component is wanted.
+    var thighY = -co * cu
+    var shinY = -ck * co * cu - sk * su
+    // The two segments are half the leg each (Leg::upperRatio).
+    return 1 + 0.5 * thighY + 0.5 * shinY
+}
+
+// Sets \a f's lift so the figure stands on whichever of its two feet reaches
+// the floor first, plus \a extra for a deliberate rise or give. Every
+// standing frame in the set goes through it, which is why a crouch here sits
+// ON the floor rather than a tenth of a leg into it and a kick does not lift
+// the standing foot off it.
+function settle(f, extra) {
+    var lead = plant(f.leadLegUp, f.leadKnee, f.leadLegOut)
+    var rear = plant(f.rearLegUp, f.rearKnee, f.rearLegOut)
+    f.lift = -Math.min(lead, rear) + (extra === undefined ? 0 : extra)
+    return f
+}
+
+// The ready stance as a frame. Every builder below starts from a copy of
+// this and changes what its move changes, which is why a move reads as the
+// handful of angles that make it and not as sixteen joints written out.
+function ready(T) {
+    var S = T.stance
+    var f = {
+        leadUp: S.leadUp, leadOut: S.leadOut, leadIn: S.leadIn,
+        leadElbow: S.leadElbow, leadWrist: S.wrist, leadRoll: S.leadRoll,
+        rearUp: S.rearUp, rearOut: S.rearOut, rearIn: S.rearIn,
+        rearElbow: S.rearElbow, rearWrist: S.wrist, rearRoll: S.rearRoll,
+
+        leadLegUp: S.leadLegUp, leadKnee: S.leadKnee, leadToe: S.leadToe,
+        leadLegOut: S.legOut, leadPivot: S.leadPivot,
+        rearLegUp: S.rearLegUp, rearKnee: S.rearKnee, rearToe: S.rearToe,
+        rearLegOut: S.legOut, rearPivot: S.rearPivot,
+
+        blade: S.blade, torsoLean: 0, torsoRoll: 0,
+        hipPitch: 0, hipYaw: 0,
+        belly: S.lean * 0.35, chest: S.lean * 0.65, chestYaw: 0, chestRoll: 0,
+        headPitch: S.headPitch, headYaw: 0, headRoll: 0,
+
+        lift: 0,
+        drift: 0,
+        hand: S.hand
+    }
+    settle(f)
+    look(f, T)
+    return f
+}
+
+// The face turns back out of the blade toward the opponent, following the
+// shoulders a little late. Called after a frame's trunk is set, so a move
+// that turns the body does not leave the head looking past the target.
+function look(f, T, k) {
+    k = k === undefined ? T.stance.headTurn : k
+    f.headYaw = -(f.blade + f.chestYaw) * k
+    return f
+}
+
+// A frame with \a over's fields written over a copy of \a f. The frames are
+// flat by design so this is the whole of frame composition.
+function over(f, o) {
+    var r = {}
+    for (var k in f) r[k] = f[k]
+    for (var j in o) r[j] = o[j]
+    return r
+}
+
+// --- shaping ------------------------------------------------------------------
+
+function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v }
+
+function easeInOutQuad(u) {
+    return u < 0.5 ? 2 * u * u : 1 - Math.pow(-2 * u + 2, 2) / 2
+}
+
+function easeOutCubic(u) { return 1 - Math.pow(1 - u, 3) }
+
+function easeInCubic(u) { return u * u * u }
+
+// The named curves a key may arrive on. "out" is the one that makes a strike
+// a strike: it covers most of its distance in the first third of its slot.
+function shape(name, u) {
+    if (name === "lin") return u
+    if (name === "out") return easeOutCubic(u)
+    if (name === "in") return easeInCubic(u)
+    if (name === "hold") return u >= 1 ? 1 : 0
+    return easeInOutQuad(u)
+}
+
+// Two frames mixed, \a k from 0 (all \a a) to 1 (all \a b). Numbers are read
+// between; the hand pose is a name and cannot be, so it changes at the
+// halfway point.
+function mixFrame(a, b, k) {
+    var r = {}
+    for (var f in a) {
+        var x = a[f], y = b[f]
+        r[f] = (typeof x === "number" && typeof y === "number")
+             ? x + (y - x) * k
+             : (k < 0.5 ? x : y)
+    }
+    return r
+}
+
+// The same, for the poses finish() answers with - the shape the animator
+// writes onto the joints. Used to ease INTO a move from wherever the body
+// happens to be standing, which is a different thing from mixing key frames:
+// the pose at the far end is already computed, and what is being blended is
+// the joints' current state.
+function mixPose(a, b, k) {
+    if (!a) return b
+    if (!b) return a
+    function v3(p, q) { return [p[0] + (q[0] - p[0]) * k,
+                                p[1] + (q[1] - p[1]) * k,
+                                p[2] + (q[2] - p[2]) * k] }
+    function limb(p, q) { return { upper: v3(p.upper, q.upper),
+                                   lower: v3(p.lower, q.lower),
+                                   hand: v3(p.hand, q.hand) } }
+    function foot(p, q) { return { upper: v3(p.upper, q.upper),
+                                   lower: v3(p.lower, q.lower),
+                                   foot: v3(p.foot, q.foot) } }
+    return {
+        rightArm: limb(a.rightArm, b.rightArm),
+        leftArm: limb(a.leftArm, b.leftArm),
+        rightLeg: foot(a.rightLeg, b.rightLeg),
+        leftLeg: foot(a.leftLeg, b.leftLeg),
+        hip: v3(a.hip, b.hip),
+        torso: v3(a.torso, b.torso),
+        belly: v3(a.belly, b.belly),
+        chest: v3(a.chest, b.chest),
+        head: v3(a.head, b.head),
+        lift: a.lift + (b.lift - a.lift) * k,
+        drift: a.drift + (b.drift - a.drift) * k,
+        hand: k < 0.5 ? a.hand : b.hand
+    }
+}
+
+// --- turning a frame into a pose ----------------------------------------------
+
+// One arm, in the shape poseAt answers with. \a side is 1 for the right arm
+// and -1 for the left. Identical to action.js's - the two models write the
+// same joints and a second convention for them would be a bug waiting.
+function arm(pitch, yaw, out, elbow, wrist, roll, side) {
+    return {
+        upper: [pitch, -side * yaw, side * out],
+        lower: [elbow, 0, 0],
+        hand: [wrist, side * roll * 90, 0]
+    }
+}
+
+function leg(upper, lower, foot, out, side, pivot) {
+    return {
+        upper: [upper, 0, (out === undefined ? 0 : out) * (side === undefined ? 1 : side)],
+        lower: [lower, 0, 0],
+        foot: [foot, pivot === undefined ? 0 : pivot, 0]
+    }
+}
+
+// The one place the frame's human signs become the joints'. Everything above
+// says "forward" and "flexed"; everything below the joints' own minus signs.
+function finish(f) {
+    return {
+        rightArm: arm(-f.rearUp, f.rearIn, f.rearOut, -f.rearElbow,
+                      f.rearWrist, f.rearRoll, 1),
+        leftArm: arm(-f.leadUp, f.leadIn, f.leadOut, -f.leadElbow,
+                     f.leadWrist, f.leadRoll, -1),
+        rightLeg: leg(-f.rearLegUp, f.rearKnee, f.rearToe, f.rearLegOut, 1, f.rearPivot),
+        leftLeg: leg(-f.leadLegUp, f.leadKnee, f.leadToe, f.leadLegOut, -1, f.leadPivot),
+        hip: [f.hipPitch, f.hipYaw, 0],
+        // The blade lives on the trunk GROUP, which carries the hips and the
+        // legs with it; the two spine segments bend on top of it.
+        torso: [f.torsoLean, f.blade, f.torsoRoll],
+        belly: [f.belly, 0, 0],
+        chest: [f.chest, f.chestYaw, f.chestRoll],
+        head: [f.headPitch, f.headYaw, f.headRoll],
+        lift: f.lift,
+        drift: f.drift,
+        hand: f.hand
+    }
+}
+
+// --- the moves ----------------------------------------------------------------
+//
+// Each entry is a section of the sheet, a duration, whether it loops, and a
+// list of keys. A key's `ease` is how the move ARRIVES at it from the key
+// before, so the shape of a strike is written where the strike lands.
+//
+// `amp` says whether effort may scale the move. Off for the two ground moves
+// only: a knockdown scaled up misses the floor, and one scaled down does not
+// reach it.
+
+var MOVES = [
+
+// ------------------------------------------------------------- standing basics
+
+{
+    name: "stance", label: "neutral stance", group: "standing",
+    ms: 2400, loop: true, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // A stance that does not breathe is a statue within two seconds.
+        // The weight goes across and the knees give a little with it.
+        var mid = over(b, {
+            leadKnee: b.leadKnee + 3, rearKnee: b.rearKnee + 3,
+            torsoRoll: 2, chestRoll: -1.2,
+            chest: b.chest + 2
+        })
+        settle(mid, -0.02)
+        return [{ t: 0, f: b },
+                { t: 0.5, f: look(mid, T) },
+                { t: 1, f: b }]
+    }
+},
+
+{
+    name: "step", label: "forward / back step", group: "standing",
+    ms: 1300, loop: true, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // Forward: the rear foot pushes, the lead knee opens, and the body
+        // travels a third of a leg over its own feet. Back: the mirror of
+        // it, shorter - stepping back is a shorter step than stepping in.
+        var fwd = over(b, {
+            drift: 0.32,
+            leadLegUp: b.leadLegUp + 6, leadKnee: b.leadKnee - 6,
+            rearLegUp: b.rearLegUp - 6, rearKnee: b.rearKnee - 6,
+            rearToe: b.rearToe + 14,
+            chest: b.chest + 4, blade: b.blade + 3
+        })
+        var back = over(b, {
+            drift: -0.18,
+            leadLegUp: b.leadLegUp - 4, leadKnee: b.leadKnee + 6,
+            rearLegUp: b.rearLegUp + 4, rearKnee: b.rearKnee + 6,
+            rearToe: b.rearToe - 8,
+            chest: b.chest - 3, blade: b.blade - 2
+        })
+        settle(fwd)
+        settle(back)
+        return [{ t: 0, f: b },
+                { t: 0.32, ease: "out", f: look(fwd, T) },
+                { t: 0.52, f: b },
+                { t: 0.82, ease: "out", f: look(back, T) },
+                { t: 1, f: b }]
+    }
+},
+
+{
+    name: "guard", label: "high guard / block", group: "standing",
+    ms: 1500, loop: true, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // The cover: both forearms come up in front of the face, the elbows
+        // stay in against the ribs, the chin tucks behind them. The whole
+        // block is that the head goes BEHIND the arms - a guard whose hands
+        // are merely higher reads as a shrug.
+        var up = over(b, {
+            leadUp: 58, leadElbow: 128, leadIn: 30, leadOut: 10,
+            rearUp: 62, rearElbow: 132, rearIn: 34, rearOut: 8,
+            headPitch: 17, chest: b.chest + 7,
+            leadKnee: b.leadKnee + 6, rearKnee: b.rearKnee + 6
+        })
+        settle(up)
+        return [{ t: 0, f: b },
+                { t: 0.34, ease: "out", f: look(up, T, 0.5) },
+                { t: 0.62, f: look(up, T, 0.5) },
+                { t: 1, f: b }]
+    }
+},
+
+{
+    name: "jab", label: "jab (straight punch)", group: "standing",
+    ms: 460, loop: false, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // A jab barely winds up - one that telegraphs is not a jab - so the
+        // load is two degrees and a breath, and the whole move is the
+        // extension and the slower way back.
+        var load = over(b, {
+            leadUp: b.leadUp - 3, leadElbow: b.leadElbow + 6,
+            blade: b.blade + 3
+        })
+        // At full extension the arm is level and nearly straight, the fist
+        // has turned over, and the lead shoulder has swung back OUT: the
+        // lead shoulder is already round toward the opponent, so a jab
+        // straight out of it crosses the centre line.
+        var out = over(b, {
+            leadUp: 88, leadElbow: 12, leadIn: -12, leadOut: 5,
+            leadRoll: 0.1, leadWrist: 0,
+            blade: b.blade + 7, chestYaw: 9,
+            leadKnee: b.leadKnee - 7, rearToe: b.rearToe + 8,
+            drift: 0.06
+        })
+        settle(load)
+        settle(out)
+        return [{ t: 0, f: b },
+                { t: 0.14, f: look(load, T) },
+                { t: 0.42, ease: "out", f: look(out, T, 0.85) },
+                { t: 0.54, f: look(out, T, 0.85) },
+                { t: 1, f: b }]
+    }
+},
+
+{
+    name: "cross", label: "cross (strong punch)", group: "standing",
+    ms: 620, loop: false, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // The cross is the trunk, not the arm: the rear fist is drawn back
+        // twice as far and for twice as long as a jab's, and then the hips
+        // turn THROUGH the blade and the rear heel comes off the floor.
+        var load = over(b, {
+            rearUp: b.rearUp - 5, rearElbow: b.rearElbow + 8,
+            blade: b.blade + 7, rearKnee: b.rearKnee + 7
+        })
+        settle(load, -0.02)
+        var out = over(b, {
+            rearUp: 92, rearElbow: 10, rearIn: 6, rearOut: 4,
+            rearRoll: 0.1, rearWrist: 0,
+            blade: b.blade - 22, chestYaw: -14,
+            chest: b.chest + 11,
+            rearLegUp: b.rearLegUp + 8, rearKnee: 12,
+            rearToe: b.rearToe + 22, rearPivot: 62,
+            leadKnee: b.leadKnee + 4,
+            drift: 0.1
+        })
+        settle(out)
+        return [{ t: 0, f: b },
+                { t: 0.2, f: look(load, T) },
+                { t: 0.46, ease: "out", f: look(out, T, 0.85) },
+                { t: 0.58, f: look(out, T, 0.85) },
+                { t: 1, f: b }]
+    }
+},
+
+{
+    name: "uppercut", label: "rising uppercut", group: "standing",
+    ms: 640, loop: false, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // A rising punch is a rising BODY: the knees fold, the fist drops
+        // below the ribs, and then the legs drive the whole figure up and
+        // the arm goes with it. Thrown from the arm alone it is a hook that
+        // happens to point upward.
+        var load = over(b, {
+            rearUp: 20, rearElbow: 55, rearIn: 26,
+            leadKnee: b.leadKnee + 12, rearKnee: b.rearKnee + 12,
+            chest: b.chest + 8, headPitch: b.headPitch + 5,
+            blade: b.blade + 6
+        })
+        settle(load, -0.03)
+        // Forearm at up + elbow = 165 degrees: the fist finishes above the
+        // head, which is where the sheet has it.
+        var up = over(b, {
+            rearUp: 85, rearElbow: 80, rearIn: 12, rearOut: 12, rearRoll: 1,
+            leadUp: 46, leadElbow: 124, leadIn: 30,
+            leadKnee: 14, rearKnee: 12,
+            chest: b.chest - 10, chestYaw: -18, blade: b.blade - 10,
+            headPitch: -8, rearToe: b.rearToe + 20, rearPivot: 52
+        })
+        settle(up, 0.04)
+        return [{ t: 0, f: b },
+                { t: 0.22, f: look(load, T) },
+                { t: 0.48, ease: "out", f: look(up, T, 0.8) },
+                { t: 0.6, f: look(up, T, 0.8) },
+                { t: 1, f: b }]
+    }
+},
+
+// ------------------------------------------------------------ crouched basics
+
+{
+    name: "lowGuard", label: "low guard / block", group: "crouched",
+    ms: 2000, loop: true, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // Dropped under the line of a high attack, guard still up. The
+        // crouch is in the knees and not in the back: a figure that folds
+        // forward instead has put its head where the block was covering.
+        var low = over(b, {
+            // A crouch that is only a few degrees lower than the stance is
+            // not a crouch: side by side on the sheet it read as the same
+            // figure. The knees fold most of a right angle, which drops the
+            // whole figure a quarter of a leg, and the rear heel comes up -
+            // a long stance folded this far cannot keep both soles down.
+            leadLegUp: 38, leadKnee: 82, rearLegUp: -10, rearKnee: 66,
+            rearToe: b.rearToe + 20,
+            leadUp: 34, leadElbow: 120, leadIn: 22,
+            rearUp: 40, rearElbow: 130, rearIn: 38,
+            chest: b.chest + 9, belly: b.belly + 3,
+            headPitch: b.headPitch + 5, blade: b.blade - 6
+        })
+        settle(low)
+        var lower = over(low, {
+            leadKnee: 88, rearKnee: 72, torsoRoll: 1.5
+        })
+        settle(lower)
+        return [{ t: 0, f: look(low, T) },
+                { t: 0.5, f: look(lower, T) },
+                { t: 1, f: look(low, T) }]
+    }
+},
+
+{
+    name: "sweep", label: "low sweep kick", group: "crouched",
+    ms: 950, loop: false, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // All the way down onto one hand, and the rear leg goes round at
+        // ankle height. The planted hand is the move: without it the figure
+        // is squatting and waving a leg, with it the weight is somewhere
+        // the leg can swing under.
+        var down = over(b, {
+            leadLegUp: 30, leadKnee: 92, rearLegUp: -18, rearKnee: 78,
+            leadUp: -26, leadElbow: 22, leadOut: 26, leadIn: -10,
+            leadRoll: 0.1, leadWrist: 20,
+            rearUp: 34, rearElbow: 96, rearIn: 30,
+            chest: b.chest + 24, belly: b.belly + 10, hipPitch: -12,
+            headPitch: 20, blade: b.blade - 8,
+            hand: "open"
+        })
+        settle(down)
+        var round = over(down, {
+            rearLegUp: -6, rearKnee: 6, rearLegOut: 62, rearToe: 8,
+            rearPivot: -20,
+            rearUp: 40, rearElbow: 70, rearIn: 40,
+            blade: b.blade - 26, chestYaw: -22, torsoRoll: 10,
+            leadKnee: 96
+        })
+        settle(round)
+        return [{ t: 0, f: b },
+                { t: 0.26, f: look(down, T, 0.5) },
+                { t: 0.56, ease: "out", f: look(round, T, 0.4) },
+                { t: 0.74, f: look(down, T, 0.5) },
+                { t: 1, f: b }]
+    }
+},
+
+// ------------------------------------------------------------ standing kicks
+
+{
+    name: "frontKick", label: "front kick", group: "kicks",
+    ms: 720, loop: false, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // Chamber first, then extend: a leg that goes out straight from the
+        // stance is a swing, and the difference between a swing and a kick
+        // is entirely the knee that came up before it.
+        var chamber = over(b, {
+            rearLegUp: 62, rearKnee: 96, rearToe: 18, rearLegOut: 4,
+            leadLegUp: 10, leadKnee: 18, leadPivot: -12,
+            leadUp: 40, leadElbow: 118, rearUp: 46, rearElbow: 130,
+            chest: b.chest - 5, blade: b.blade - 6
+        })
+        settle(chamber)
+        var out = over(chamber, {
+            rearLegUp: 112, rearKnee: 8, rearToe: 26,
+            leadKnee: 14, leadPivot: -18,
+            leadUp: 12, leadElbow: 58, leadOut: 34,
+            rearUp: 54, rearElbow: 118, rearOut: 20,
+            chest: b.chest - 14, belly: b.belly - 6, hipPitch: -8,
+            headPitch: 0, blade: b.blade - 10
+        })
+        settle(out, 0.02)
+        return [{ t: 0, f: b },
+                { t: 0.24, f: look(chamber, T, 0.8) },
+                { t: 0.48, ease: "out", f: look(out, T, 0.8) },
+                { t: 0.6, f: look(out, T, 0.8) },
+                { t: 1, f: b }]
+    }
+},
+
+{
+    name: "roundhouse", label: "high roundhouse kick", group: "kicks",
+    ms: 860, loop: false, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // Round rather than straight: the leg is chambered out to the SIDE,
+        // the supporting foot turns its heel toward the target, and the
+        // trunk falls away from the kick to pay for the height.
+        var chamber = over(b, {
+            rearLegUp: 78, rearKnee: 100, rearLegOut: 34, rearToe: 16,
+            leadKnee: 20, leadPivot: -26,
+            torsoRoll: -10, blade: b.blade + 8,
+            leadUp: 44, leadElbow: 118, rearUp: 36, rearElbow: 110
+        })
+        settle(chamber)
+        // HOW HIGH A ROUND KICK GETS is not the pitch alone. The leg is
+        // carried out to the side first and pitched forward second (the
+        // joint's rotations are applied Z, then X, then Y), so the swing out
+        // is also the CEILING: a leg carried d degrees out cannot be lifted
+        // past 90 - d above the horizontal however hard it is pitched, and at
+        // sixty out - which is what a round kick looks like on paper - the
+        // foot cannot reach higher than the belt. A third of a turn out and a
+        // pitch well past the vertical is what puts it at chest height, and
+        // what makes the kick read as ROUND is then the trunk falling away
+        // from it and the supporting heel turning, not the leg's own swing.
+        var out = over(chamber, {
+            rearLegUp: 136, rearKnee: 10, rearLegOut: 34, rearToe: 24,
+            leadKnee: 12, leadPivot: -58, leadLegUp: b.leadLegUp - 8,
+            torsoRoll: -28, blade: b.blade - 18, chestYaw: -20,
+            leadUp: 52, leadElbow: 104, leadIn: 40,
+            rearUp: 14, rearElbow: 42, rearOut: 30,
+            chest: b.chest - 6
+        })
+        settle(out, 0.03)
+        return [{ t: 0, f: b },
+                { t: 0.26, f: look(chamber, T, 0.8) },
+                { t: 0.54, ease: "out", f: look(out, T, 0.55) },
+                { t: 0.66, f: look(out, T, 0.55) },
+                { t: 1, f: b }]
+    }
+},
+
+// --------------------------------------------------------------- airborne moves
+
+{
+    name: "jumpPunch", label: "jumping forward punch", group: "airborne",
+    ms: 840, loop: false, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        // Crouch, leave the floor, land in a crouch. The legs TRAIL behind
+        // the punch in the air - a figure that keeps its stance airborne
+        // reads as being lifted rather than as jumping.
+        var load = over(b, {
+            leadKnee: 55, rearKnee: 55, leadLegUp: 22, rearLegUp: -16,
+            leadUp: 10, leadElbow: 90, rearUp: 14, rearElbow: 95,
+            chest: b.chest + 12, headPitch: b.headPitch + 6
+        })
+        settle(load)
+        var air = over(b, {
+            lift: 0.62, drift: 0.42, torsoLean: 24,
+            leadLegUp: -18, leadKnee: 42, leadToe: 28,
+            rearLegUp: -34, rearKnee: 56, rearToe: 32,
+            leadUp: 96, leadElbow: 8, leadIn: -10, leadOut: 5, leadRoll: 0.1,
+            rearUp: 8, rearElbow: 48, rearOut: 26,
+            blade: b.blade - 14, chestYaw: -16, headPitch: -4
+        })
+        var land = over(load, {
+            drift: 0.28, leadKnee: 62, rearKnee: 60,
+            chest: b.chest + 16
+        })
+        settle(land)
+        return [{ t: 0, f: b },
+                { t: 0.18, f: look(load, T) },
+                { t: 0.46, ease: "out", f: look(air, T, 0.8) },
+                { t: 0.66, ease: "in", f: look(land, T) },
+                { t: 1, f: b }]
+    }
+},
+
+{
+    name: "jumpKick", label: "jumping side kick", group: "airborne",
+    ms: 920, loop: false, amp: true,
+    keys: function (T) {
+        var b = ready(T)
+        var load = over(b, {
+            leadKnee: 58, rearKnee: 58, leadLegUp: 22, rearLegUp: -16,
+            leadUp: 14, leadElbow: 86, rearUp: 16, rearElbow: 92,
+            chest: b.chest + 12
+        })
+        settle(load)
+        // In the air the body lies back behind the kicking leg and the other
+        // knee folds up under it; the arms go out because there is nothing
+        // else to balance against.
+        var air = over(b, {
+            lift: 0.7, drift: 0.3, torsoLean: -18,
+            rearLegUp: 88, rearKnee: 6, rearToe: 24, rearLegOut: 10,
+            leadLegUp: 46, leadKnee: 104, leadToe: 22,
+            leadUp: 62, leadElbow: 58, leadOut: 40, leadIn: -8,
+            rearUp: 30, rearElbow: 68, rearOut: 34,
+            blade: b.blade - 8, headPitch: -2
+        })
+        var land = over(load, {
+            drift: 0.16, leadKnee: 64, rearKnee: 60,
+            chest: b.chest + 16
+        })
+        settle(land)
+        return [{ t: 0, f: b },
+                { t: 0.18, f: look(load, T) },
+                { t: 0.48, ease: "out", f: look(air, T, 0.7) },
+                { t: 0.68, ease: "in", f: look(land, T) },
+                { t: 1, f: b }]
+    }
+},
+
+// ------------------------------------------------------------ ground & recovery
+
+{
+    name: "knockdown", label: "knockdown / fall", group: "ground",
+    ms: 950, loop: false, holds: true, amp: false,
+    keys: function (T) {
+        var b = ready(T)
+        // The one move that does not come back to the stance: it ends on the
+        // floor and STAYS there, because the next thing a knocked-down
+        // figure does is get up, and that is the move after this one.
+        var hit = over(b, {
+            chest: b.chest - 16, headPitch: -14, torsoLean: -8,
+            leadUp: 50, leadElbow: 38, leadOut: 40, leadIn: -20,
+            rearUp: 46, rearElbow: 34, rearOut: 42, rearIn: -18,
+            leadKnee: 34, rearKnee: 30, drift: -0.14,
+            hand: "open"
+        })
+        settle(hit)
+        var falling = over(hit, {
+            torsoLean: -46, hipPitch: 14,
+            leadKnee: 66, rearKnee: 54, leadLegUp: 30, rearLegUp: 8,
+            drift: -0.3, lift: -0.62
+        })
+        return [{ t: 0, f: b },
+                { t: 0.24, ease: "out", f: look(hit, T, 0.4) },
+                { t: 0.58, ease: "in", f: look(falling, T, 0.3) },
+                { t: 1, ease: "out", f: down(T) }]
+    }
+},
+
+{
+    name: "getUp", label: "get-up / recovery", group: "ground",
+    ms: 1150, loop: false, amp: false,
+    keys: function (T) {
+        var b = ready(T)
+        // Starts where the knockdown ended - the same frame, so the two are
+        // one movement whichever way they are triggered - rolls onto a hand
+        // and a knee, and stands up into the stance.
+        var d = down(T)
+        var roll = over(d, {
+            torsoLean: -46, torsoRoll: 26, hipPitch: 34,
+            leadUp: -18, leadElbow: 16, leadOut: 30, leadWrist: 22,
+            leadKnee: 96, rearKnee: 82, leadLegUp: 48, rearLegUp: 26,
+            headPitch: 10, lift: -0.88, drift: -0.28
+        })
+        // Up on one hand and one knee: the sheet's last panel.
+        var braced = over(d, {
+            torsoLean: 40, torsoRoll: 8, hipPitch: -14,
+            leadUp: -14, leadElbow: 12, leadOut: 24, leadWrist: 24,
+            rearUp: 18, rearElbow: 44, rearOut: 34, rearIn: -22,
+            leadLegUp: 42, leadKnee: 102, rearLegUp: -32, rearKnee: 92,
+            rearToe: 30, headPitch: -12, chest: 10, belly: 4,
+            lift: -0.6, drift: -0.14
+        })
+        return [{ t: 0, f: d },
+                { t: 0.3, f: roll },
+                { t: 0.64, ease: "out", f: braced },
+                { t: 1, ease: "out", f: b }]
+    }
+}
+
+]
+
+// Flat on the back, knees up: the frame the knockdown ends on and the get-up
+// starts from. The whole figure is pitched back about the waist joint, which
+// carries the hips and the legs with it, and dropped by whatever the waist
+// stands at - so a tall character falls further than a short one and both
+// end up on the floor.
+function down(T) {
+    var b = ready(T)
+    return over(b, {
+        torsoLean: -82, torsoRoll: 4, blade: b.blade - 10,
+        hipPitch: 26, chest: -6, belly: -3,
+        leadLegUp: 40, leadKnee: 66, rearLegUp: 24, rearKnee: 52,
+        leadToe: 10, rearToe: 8, leadPivot: 0, rearPivot: 0,
+        leadLegOut: 16, rearLegOut: 16,
+        leadUp: 62, leadElbow: 24, leadOut: 55, leadIn: -25, leadRoll: 0.2,
+        rearUp: 55, rearElbow: 28, rearOut: 50, rearIn: -22, rearRoll: 0.2,
+        headPitch: 18, headYaw: 12, headRoll: 0,
+        hand: "open",
+        drift: -0.35,
+        lift: T.downLift
+    })
+}
+
+var MOVE_NAMES = MOVES.map(function (m) { return m.name })
+
+function byName(name) {
+    for (var i = 0; i < MOVES.length; i++)
+        if (MOVES[i].name === name) return MOVES[i]
+    return null
+}
+
+function known(name) { return byName(name) !== null }
+
+// The name of the move a character in this set stands in when it is doing
+// nothing else. What MoveSet falls back to when a one-shot finishes.
+function restMove() { return "stance" }
+
+// --- deriving a table ---------------------------------------------------------
+
+// \a opts is what the animator was configured with: {intensity} always, and -
+// when the caller has a body - {legHeight, hipHeight, footHeight, torsoDepth}
+// in the body's own units, so the fall lands on the floor of THIS figure
+// rather than of the one the numbers were written against.
+//
+// Everything is folded in here so poseAt() only ever reads finished numbers,
+// exactly as gait.js and action.js do it.
+function derive(name, opts) {
+    var m = byName(name)
+    if (m === null)
+        return derive("stance", opts)
+    opts = opts || {}
+    var intensity = opts.intensity === undefined ? 0.5 : clamp(opts.intensity, 0, 1)
+
+    // Where the waist stands, in leg heights, so a fall can put it on the
+    // floor. Without a body it is the default figure's, which is what the
+    // set was authored against.
+    var downLift = -1.18
+    if (opts.legHeight > 0) {
+        var foot = opts.footHeight === undefined ? 0.5 : opts.footHeight
+        var hip = opts.hipHeight === undefined ? 1.167 : opts.hipHeight
+        var deep = opts.torsoDepth === undefined ? 1.25 : opts.torsoDepth
+        downLift = -(foot + opts.legHeight + hip - deep * 0.55) / opts.legHeight
+    }
+
+    var T = { stance: STANCE, downLift: downLift }
+    var keys = m.keys(T)
+
+    // Effort is the SIZE of a move and its speed, never a different pose:
+    // every key is mixed toward the ready stance, so a light jab is the same
+    // jab shorter and a hard one the same jab further. Deliberately allowed
+    // a little past 1 - an amateur throwing hard throws past the target -
+    // and kept off the two ground moves, where the floor is not negotiable.
+    if (m.amp) {
+        var k = 0.85 + intensity * 0.34
+        var rest = ready(T)
+        keys = keys.map(function (key) {
+            return { t: key.t, ease: key.ease, f: mixFrame(rest, key.f, k) }
+        })
+    }
+
+    return {
+        name: "martialarts",
+        move: m.name,
+        label: m.label,
+        group: m.group,
+        loop: m.loop === true,
+        holds: m.holds === true,
+        keys: keys,
+        stanceFrame: ready(T),
+        downLift: downLift,
+        hand: keys[0].f.hand,
+        // A harder move is a faster one. Bounded either way: the animation
+        // is read frame by frame and something under a fifth of a second is
+        // a flicker rather than a strike.
+        cycleMs: Math.max(180, Math.round(m.ms / (0.78 + intensity * 0.44)))
+    }
+}
+
+// --- the pose -----------------------------------------------------------------
+
+// The pose \a table holds at phase \a t of its move, 0..1. Pure: the same
+// answer the running move gives at that moment, which is what lets a sheet of
+// stills be drawn from it and a suite assert on it.
+//
+// The wrist roll comes back as a FRACTION of a quarter turn rather than in
+// degrees, because the degrees belong to the character (handRestRoll) and not
+// to the move. Whoever applies the pose multiplies.
+function poseAt(table, t) {
+    return finish(frameAt(table, t))
+}
+
+// The frame at phase \a t: the two keys around it, mixed on the curve the
+// later of the two arrives on.
+//
+// A LOOPING move wraps - phase 1.25 is phase 0.25 - and a ONE-SHOT does not:
+// its phase 1 is the end of the move and has to stay there, which is the
+// whole of how the knockdown ends up on the floor rather than back on its
+// feet.
+function frameAt(table, t) {
+    var keys = table.keys
+    t = table.loop ? t - Math.floor(t) : clamp(t, 0, 1)
+    if (keys.length === 1)
+        return keys[0].f
+    var i = 0
+    while (i < keys.length - 1 && t >= keys[i + 1].t) i++
+    if (i >= keys.length - 1)
+        return keys[keys.length - 1].f
+    var a = keys[i], b = keys[i + 1]
+    var span = b.t - a.t
+    var u = span <= 0 ? 1 : clamp((t - a.t) / span, 0, 1)
+    return mixFrame(a.f, b.f, shape(b.ease === undefined ? "inout" : b.ease, u))
+}
+
+// What the set offers, in the order the sheet lists it: enough for a UI to
+// build a row of buttons without knowing anything about martial arts.
+function moves() {
+    return MOVES.map(function (m) {
+        return { name: m.name, label: m.label, group: m.group,
+                 loop: m.loop === true, holds: m.holds === true }
+    })
+}

--- a/plugins/clay_character3d/movesets/martialarts.test.js
+++ b/plugins/clay_character3d/movesets/martialarts.test.js
@@ -1,0 +1,382 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+//
+// Unit suite for the martial-arts move set - the fourteen moves of the
+// reference sheet (#238).
+//
+//     node plugins/clay_character3d/movesets/martialarts.test.js
+//
+// What it exists to pin is the set of claims a still cannot make. A
+// screenshot shows a figure with its foot up; it cannot show that the foot
+// came down again on the floor rather than a tenth of a leg into it, that the
+// hand which is not punching stayed home, that the jab is the LEAD arm and the
+// cross the REAR one, or that the knockdown ends on exactly the frame the
+// get-up starts from - which is the whole reason those two are one movement
+// and not two animations that nearly meet. It also pins what effort is
+// allowed to be: the size of a move and its speed, never a different pose,
+// and never anything at all on the two ground moves, where the floor is not
+// negotiable.
+const K = require('../../../labs/kits/kitcheck.js')
+
+const M = K.load(__dirname, 'martialarts.js', [
+    'STANCE', 'MOVES', 'MOVE_NAMES', 'moves', 'known', 'byName', 'restMove',
+    'derive', 'poseAt', 'frameAt', 'ready', 'down', 'plant', 'settle',
+    'mixFrame', 'mixPose', 'finish', 'arm', 'leg', 'over', 'look', 'shape', 'clamp'
+])
+
+const ok = K.ok, eq = K.eq, near = K.near, section = K.section
+const rad = Math.PI / 180
+
+// The engine applies eulerRotation as Z, then X, then Y, and the order is not
+// a detail here: a limb is swung OUT on Z and pitched forward on X, so the
+// swing out is also the ceiling on how high the pitch can carry it. Rotating
+// in any other order would answer a different, higher foot for the roundhouse
+// than the one the character actually shows.
+function rot(v, e) {
+  const cz = Math.cos(e[2] * rad), sz = Math.sin(e[2] * rad)
+  let a = [v[0] * cz - v[1] * sz, v[0] * sz + v[1] * cz, v[2]]
+  const cx = Math.cos(e[0] * rad), sx = Math.sin(e[0] * rad)
+  a = [a[0], a[1] * cx - a[2] * sx, a[1] * sx + a[2] * cx]
+  const cy = Math.cos(e[1] * rad), sy = Math.sin(e[1] * rad)
+  return [a[0] * cy + a[2] * sy, a[1], -a[0] * sy + a[2] * cy]
+}
+
+// Where a limb's tip ends up, in limb lengths from the shoulder or the hip:
+// +y up, +z forward, +x to the character's right. Two equal segments, which
+// is the arm and is also Leg::upperRatio 0.5, followed from a rest direction
+// of straight down through the lower joint and then the upper one.
+function tip(j) {
+  const d = [0, -1, 0]
+  const u = rot(d, j.upper)
+  const l = rot(rot(d, j.lower), j.upper)
+  return [0.5 * u[0] + 0.5 * l[0], 0.5 * u[1] + 0.5 * l[1], 0.5 * u[2] + 0.5 * l[2]]
+}
+
+// The joint between the two segments, in the same frame.
+function joint(j) {
+  const u = rot([0, -1, 0], j.upper)
+  return [0.5 * u[0], 0.5 * u[1], 0.5 * u[2]]
+}
+
+// How far above or below the floor the lower of the two feet is. A planted
+// foot sits at -1.0: settle() puts the figure's lift at minus whatever the
+// more extended of its two legs is shortened by, and the tip of that leg is
+// exactly that much above the hip's own zero.
+function floorGap(p) {
+  return Math.min(p.lift + tip(p.rightLeg)[1], p.lift + tip(p.leftLeg)[1])
+}
+
+// The pose over the whole phase at which \a f is largest, and the phase it is
+// at: a strike is judged at its peak and the peak is where the key holds.
+function peak(T, f) {
+  let best = -Infinity, at = 0
+  for (let i = 0; i <= 400; i++) {
+    const p = M.poseAt(T, i / 400)
+    const v = f(p)
+    if (v > best) { best = v; at = i / 400 }
+  }
+  return { value: best, t: at, pose: M.poseAt(T, at) }
+}
+
+// The largest difference between any two matching numbers in two poses.
+function apart(p, q) {
+  let worst = 0
+  ;(function walk(a, b) {
+    if (Array.isArray(a)) { a.forEach((v, i) => walk(v, b[i])); return }
+    if (a !== null && typeof a === 'object') { for (const k in a) walk(a[k], b[k]); return }
+    if (typeof a === 'number') worst = Math.max(worst, Math.abs(a - b))
+  })(p, q)
+  return worst
+}
+
+const AIRBORNE = ['jumpPunch', 'jumpKick']
+const GROUND = ['knockdown', 'getUp']
+const STANDING = M.MOVE_NAMES.filter(n => AIRBORNE.indexOf(n) < 0 && GROUND.indexOf(n) < 0)
+
+// ---------------------------------------------------------------------- the set
+section('the set is the fourteen moves of the sheet, in the order of the sheet')
+{
+  const sheet = ['stance', 'step', 'guard', 'jab', 'cross', 'uppercut', 'lowGuard',
+                 'sweep', 'frontKick', 'roundhouse', 'jumpPunch', 'jumpKick',
+                 'knockdown', 'getUp']
+  eq('all fourteen are there, by name and in order',
+     M.MOVE_NAMES.join(','), sheet.join(','))
+  const list = M.moves()
+  eq('and moves() answers one entry per move', list.length, M.MOVE_NAMES.length)
+  eq('in the same order', list.map(m => m.name).join(','), M.MOVE_NAMES.join(','))
+  ok('each carrying a name, a label, a group, whether it loops and whether it holds',
+     list.every(m => typeof m.name === 'string' && m.label.length > 0
+                  && typeof m.group === 'string'
+                  && typeof m.loop === 'boolean' && typeof m.holds === 'boolean'))
+  eq('the groups are the sheet\'s five',
+     [...new Set(list.map(m => m.group))].join(','),
+     'standing,crouched,kicks,airborne,ground')
+  ok('the knockdown is the one move that holds where it ends',
+     list.filter(m => m.holds).map(m => m.name).join(',') === 'knockdown')
+  ok('it knows a move it has', M.known('jab') && M.byName('jab') !== null)
+  ok('and does not know one it has not', !M.known('juggle') && M.byName('juggle') === null)
+  eq('an unknown move falls back to the stance rather than throwing',
+     M.derive('juggle').move, 'stance')
+  eq('and the stance is what the figure rests in', M.restMove(), 'stance')
+}
+
+// -------------------------------------------------------------------- chaining
+section('every move starts and ends somewhere the next one can pick up from')
+{
+  // This is what makes a one-shot hand back and a loop loop: the first and
+  // last key of every move are the same ready stance, so the pose either end
+  // of it is the same pose and no two moves can be chained into a jump.
+  for (const n of M.MOVE_NAMES) {
+    if (GROUND.indexOf(n) >= 0) continue
+    const T = M.derive(n)
+    eq(n + ' ends where it began',
+       JSON.stringify(M.poseAt(T, 1)), JSON.stringify(M.poseAt(T, 0)))
+  }
+  eq('the knockdown ends on the down frame and the get-up starts on that same frame',
+     JSON.stringify(M.poseAt(M.derive('getUp'), 0)),
+     JSON.stringify(M.poseAt(M.derive('knockdown'), 1)))
+  eq('and the get-up ends standing in the ready stance',
+     JSON.stringify(M.poseAt(M.derive('getUp'), 1)),
+     JSON.stringify(M.poseAt(M.derive('stance'), 0)))
+}
+
+section('a one-shot does not wrap and a loop does')
+{
+  const loop = M.derive('stance'), shot = M.derive('knockdown')
+  ok('the stance is a loop and the knockdown is not', loop.loop && !shot.loop)
+  eq('a loop read past its end is read from its start again',
+     JSON.stringify(M.poseAt(loop, 1.25)), JSON.stringify(M.poseAt(loop, 0.25)))
+  eq('and read before its start from its end',
+     JSON.stringify(M.poseAt(loop, -0.75)), JSON.stringify(M.poseAt(loop, 0.25)))
+  eq('a one-shot read past its end stays on its last frame',
+     JSON.stringify(M.poseAt(shot, 1.5)), JSON.stringify(M.poseAt(shot, 1)))
+  eq('and read before its start stays on its first',
+     JSON.stringify(M.poseAt(shot, -0.5)), JSON.stringify(M.poseAt(shot, 0)))
+  // The knockdown has to STAY on the floor: a one-shot that wrapped would put
+  // a knocked-down figure back on its feet by itself.
+  ok('so the knockdown is still on the floor long after it landed',
+     M.poseAt(shot, 4).lift === M.poseAt(shot, 1).lift)
+}
+
+// ---------------------------------------------------------------------- the floor
+section('the figure stands on the floor and does not stand in it')
+{
+  for (const n of STANDING) {
+    const T = M.derive(n)
+    let lo = Infinity, hi = -Infinity
+    for (let i = 0; i <= 400; i++) {
+      const g = floorGap(M.poseAt(T, i / 400))
+      lo = Math.min(lo, g); hi = Math.max(hi, g)
+    }
+    ok(n + ' keeps its lower foot on the floor throughout',
+       lo > -1.07 && hi < -0.93, 'lowest ' + lo.toFixed(4) + ', highest ' + hi.toFixed(4))
+  }
+  for (const n of AIRBORNE) {
+    const T = M.derive(n)
+    let lo = Infinity, hi = -Infinity
+    for (let i = 0; i <= 400; i++) {
+      const g = floorGap(M.poseAt(T, i / 400))
+      lo = Math.min(lo, g); hi = Math.max(hi, g)
+    }
+    ok(n + ' leaves the floor', hi > -0.5, 'highest ' + hi.toFixed(4))
+    ok('and lands on it again', lo <= -1.0, 'lowest ' + lo.toFixed(4))
+  }
+}
+
+// -------------------------------------------------------------------- the strikes
+section('a jab is the lead hand and a cross is the rear')
+{
+  const jab = peak(M.derive('jab'), p => tip(p.leftArm)[2])
+  const cross = peak(M.derive('cross'), p => tip(p.rightArm)[2])
+  ok('the jab puts the left hand out at reach',
+     jab.value > 0.9, 'reached ' + jab.value.toFixed(4))
+  ok('and the right hand stays home', tip(jab.pose.rightArm)[2] < 0.6,
+     'right at ' + tip(jab.pose.rightArm)[2].toFixed(4))
+  ok('the cross puts the right hand out at reach',
+     cross.value > 0.9, 'reached ' + cross.value.toFixed(4))
+  ok('and the left hand stays home', tip(cross.pose.leftArm)[2] < 0.6,
+     'left at ' + tip(cross.pose.leftArm)[2].toFixed(4))
+  ok('the cross is the longer move of the two',
+     M.derive('cross').cycleMs > M.derive('jab').cycleMs)
+  // The cross is the trunk, not the arm: the hips turn THROUGH the blade,
+  // where a jab only turns further into it.
+  ok('the cross turns the trunk through the stance\'s blade',
+     jab.pose.torso[1] > M.STANCE.blade && cross.pose.torso[1] < M.STANCE.blade,
+     'jab ' + jab.pose.torso[1].toFixed(2) + ', stance ' + M.STANCE.blade
+     + ', cross ' + cross.pose.torso[1].toFixed(2))
+}
+
+section('an uppercut rises and a guard covers')
+{
+  const up = peak(M.derive('uppercut'), p => tip(p.rightArm)[1])
+  ok('the rear fist finishes above the shoulder',
+     up.value > 0.35, 'fist at ' + up.value.toFixed(4))
+  // What separates a rising punch from an overhead swing: the elbow does not
+  // go up with the fist.
+  ok('and the elbow does not go up with it',
+     joint(up.pose.rightArm)[1] <= 0,
+     'elbow at ' + joint(up.pose.rightArm)[1].toFixed(4))
+
+  const cover = M.poseAt(M.derive('guard'), 0.5)
+  for (const [name, a] of [['the rear', cover.rightArm], ['the lead', cover.leftArm]]) {
+    ok(name + ' fist comes up above its own elbow', tip(a)[1] > joint(a)[1])
+    ok('and ' + name + ' fist comes up past the shoulder line', tip(a)[1] > 0,
+       'fist at ' + tip(a)[1].toFixed(4))
+  }
+}
+
+// ----------------------------------------------------------------------- the kicks
+section('the kicks go where their names say and chamber before they go')
+{
+  const front = peak(M.derive('frontKick'), p => tip(p.rightLeg)[1])
+  const round = peak(M.derive('roundhouse'), p => tip(p.rightLeg)[1])
+  ok('the front kick puts the right foot above the hip',
+     front.value > 0.2, 'foot at ' + front.value.toFixed(4))
+  ok('and well forward of it', tip(front.pose.rightLeg)[2] > 0.7,
+     'forward ' + tip(front.pose.rightLeg)[2].toFixed(4))
+  ok('the roundhouse gets the same foot higher still', round.value > front.value,
+     'round ' + round.value.toFixed(4) + ' vs front ' + front.value.toFixed(4))
+
+  function sideways(T) {
+    let out = 0
+    for (let i = 0; i <= 400; i++)
+      out = Math.max(out, Math.abs(tip(M.poseAt(T, i / 400).rightLeg)[0]))
+    return out
+  }
+  const roundX = sideways(M.derive('roundhouse')), frontX = sideways(M.derive('frontKick'))
+  ok('and takes it further out to the side', roundX > frontX,
+     'round ' + roundX.toFixed(4) + ' vs front ' + frontX.toFixed(4))
+
+  // A leg that goes out straight from the stance is a swing; the knee that
+  // came up first is the whole difference.
+  for (const [n, chamberT, outT] of [['the front kick', 0.24, 0.48],
+                                     ['the roundhouse', 0.26, 0.54]]) {
+    const T = M.derive(n === 'the front kick' ? 'frontKick' : 'roundhouse')
+    const folded = M.poseAt(T, chamberT).rightLeg.lower[0]
+    const straight = M.poseAt(T, outT).rightLeg.lower[0]
+    ok(n + ' chambers the knee before it extends', folded > straight * 4,
+       'chamber ' + folded.toFixed(1) + ', extension ' + straight.toFixed(1))
+  }
+}
+
+section('the sweep stays low and goes down onto a hand')
+{
+  const T = M.derive('sweep')
+  let high = -Infinity, out = 0
+  for (let i = 0; i <= 400; i++) {
+    const v = tip(M.poseAt(T, i / 400).rightLeg)
+    high = Math.max(high, v[1]); out = Math.max(out, Math.abs(v[0]))
+  }
+  ok('the sweeping foot never comes up to the hip', high < 0,
+     'highest ' + high.toFixed(4))
+  ok('and goes a long way out to the side', out > 0.6, 'out ' + out.toFixed(4))
+  // The planted hand IS the move: without it the figure is squatting and
+  // waving a leg.
+  eq('the hand opens to plant through the middle of it', M.poseAt(T, 0.5).hand, 'open')
+  eq('and is a fist at the start', M.poseAt(T, 0).hand, 'fist')
+  eq('and a fist again at the end', M.poseAt(T, 1).hand, 'fist')
+}
+
+// -------------------------------------------------------------------------- effort
+section('effort is size and speed, never a different pose')
+{
+  for (const n of M.MOVE_NAMES) {
+    const calm = M.derive(n, { intensity: 0 }).cycleMs
+    const hard = M.derive(n, { intensity: 1 }).cycleMs
+    ok('a harder ' + n + ' is a faster one', hard < calm,
+       'hard ' + hard + ', calm ' + calm)
+    ok('and still not a flicker', hard >= 180, 'hard ' + hard)
+  }
+  const light = peak(M.derive('jab', { intensity: 0 }), p => tip(p.leftArm)[2])
+  const hard = peak(M.derive('jab', { intensity: 1 }), p => tip(p.leftArm)[2])
+  ok('a hard jab reaches further than a light one', hard.value > light.value,
+     'hard ' + hard.value.toFixed(4) + ', light ' + light.value.toFixed(4))
+  ok('and a light one still reaches forward', light.value > 0.8,
+     'light ' + light.value.toFixed(4))
+  for (const n of ['jab', 'roundhouse']) {
+    eq('intensity is clamped on the ' + n, M.derive(n, { intensity: 9 }).cycleMs,
+       M.derive(n, { intensity: 1 }).cycleMs)
+  }
+  // A knockdown scaled up misses the floor and one scaled down does not
+  // reach it, so effort is kept off the two ground moves entirely.
+  for (const n of GROUND) {
+    eq('effort does not touch the ' + n,
+       JSON.stringify(M.derive(n, { intensity: 0 }).keys),
+       JSON.stringify(M.derive(n, { intensity: 1 }).keys))
+  }
+}
+
+// ---------------------------------------------------------------------- the fall
+section('the fall lands on the floor of this figure')
+{
+  const tall = M.derive('knockdown',
+    { legHeight: 4, hipHeight: 1.6, footHeight: 0.5, torsoDepth: 1.25 }).downLift
+  const short = M.derive('knockdown',
+    { legHeight: 4, hipHeight: 0.9, footHeight: 0.5, torsoDepth: 1.25 }).downLift
+  ok('a figure whose waist stands higher is dropped further', tall < short,
+     'tall ' + tall.toFixed(4) + ', short ' + short.toFixed(4))
+  near('and with no body given it is the default figure\'s',
+       M.derive('knockdown').downLift, -1.18, 1e-9)
+  const p = M.poseAt(M.derive('knockdown'), 1)
+  ok('the down frame pitches the whole trunk onto its back', p.torso[0] < -60,
+     'torso ' + p.torso[0].toFixed(1))
+  eq('and opens the hands', p.hand, 'open')
+  eq('and the fall drops the figure by exactly that much', p.lift, M.derive('knockdown').downLift)
+}
+
+// --------------------------------------------------------------------- the edges
+section('the mixers read numbers between and switch names at the halfway point')
+{
+  const a = { angle: 0, lift: -1, hand: 'fist' }
+  const b = { angle: 10, lift: 0, hand: 'open' }
+  near('a number a quarter of the way is a quarter of the way',
+       M.mixFrame(a, b, 0.25).angle, 2.5, 1e-12)
+  eq('a name is the first one before the halfway point', M.mixFrame(a, b, 0.49).hand, 'fist')
+  eq('and the second one at it', M.mixFrame(a, b, 0.5).hand, 'open')
+  near('and the numbers keep reading between either way',
+       M.mixFrame(a, b, 0.5).lift, -0.5, 1e-12)
+
+  const stand = M.poseAt(M.derive('stance'), 0)
+  const punch = M.poseAt(M.derive('cross'), 0.46)
+  eq('a pose mixed nowhere is the pose it started at',
+     JSON.stringify(M.mixPose(stand, punch, 0)), JSON.stringify(stand))
+  // Not JSON-identical at the far end: p + (q - p) is q only to within
+  // floating point, and it comes out about 5e-15 off on one wrist angle.
+  ok('and a pose mixed all the way is the pose it was going to',
+     apart(M.mixPose(stand, punch, 1), punch) < 1e-12
+     && M.mixPose(stand, punch, 1).hand === punch.hand,
+     'off by ' + apart(M.mixPose(stand, punch, 1), punch))
+  const half = M.mixPose(stand, punch, 0.5)
+  near('and half way it is half way in lift', half.lift, (stand.lift + punch.lift) / 2, 1e-12)
+  near('and half way in drift', half.drift, (stand.drift + punch.drift) / 2, 1e-12)
+}
+
+section('a bent leg is a shorter leg')
+{
+  eq('a straight leg carried straight down takes nothing off the height',
+     M.plant(0, 0, 0), 0)
+  ok('a folded knee takes some off', M.plant(0, 30, 0) > 0)
+  ok('and a further folded one takes more', M.plant(0, 60, 0) > M.plant(0, 30, 0))
+  // The leg is also carried out to the side, and the sheet's stances are wide
+  // enough that ignoring that puts a deep crouch into the ground.
+  ok('and a leg carried out to the side takes more off than one hanging under the hip',
+     M.plant(0, 60, 30) > M.plant(0, 60, 0))
+}
+
+section('every pose carries what an animator has to write')
+{
+  for (const n of M.MOVE_NAMES) {
+    const p = M.poseAt(M.derive(n), 0.37)
+    ok(n + ' answers with a lift, a drift and a hand',
+       typeof p.lift === 'number' && typeof p.drift === 'number'
+       && (p.hand === 'fist' || p.hand === 'open'))
+  }
+  const T = M.derive('cross')
+  eq('poseAt is frameAt finished', JSON.stringify(M.poseAt(T, 0.3)),
+     JSON.stringify(M.finish(M.frameAt(T, 0.3))))
+  eq('the shape curves start where they start', M.shape('out', 0), 0)
+  eq('and end where they end', M.shape('out', 1), 1)
+  eq('a hold is nothing until it is everything', M.shape('hold', 0.99), 0)
+  eq('clamp holds the ends', M.clamp(9, 0, 1), 1)
+}
+
+process.exit(K.report('martial arts move set'))

--- a/plugins/clay_character3d/tests/qml_head/tst_moveset.qml
+++ b/plugins/clay_character3d/tests/qml_head/tst_moveset.qml
@@ -1,0 +1,247 @@
+// (c) Clayground Contributors - MIT License, see "LICENSE" file
+//
+// Loadable move sets (#238): a set that is loaded onto a character rather
+// than instantiated with every one of them.
+//
+// This needs the BUILT module - a Character is made of Box3D, whose geometry
+// is C++ in Canvas3D - so it is one of the halves Windows has to skip (#192).
+// The angles themselves are checked by node in movesets/martialarts.test.js;
+// what is left for this suite is everything that only exists once a set is
+// actually loaded onto a running character: that loading and unloading work
+// at all, that a move owns the joints while it runs and hands them back when
+// it stops, that a knockdown STAYS on the floor, and that the set and the
+// activity state machine do not fight over the body.
+
+import QtQuick
+import QtTest
+import Clayground.Character3D
+
+Item {
+    id: root
+    width: 50; height: 50
+
+    TestCase {
+        id: tc
+        name: "MoveSet"
+        when: windowShown
+
+        Character {
+            id: c
+            legHeight: 5.0
+            footHeight: 0.4
+            hipHeight: 1.0
+            torsoDepth: 1.2
+        }
+
+        function init() {
+            // IdleAnim zeroes every joint over its first 200 ms; a test that
+            // reads a joint before that has finished is reading under it.
+            c.moveSet = ""
+            c.activity = Character.Activity.Idle
+            wait(300)
+        }
+
+        function cleanupTestCase() {
+            c.moveSet = ""
+        }
+
+        function test_a_character_carries_no_set_until_one_is_loaded() {
+            compare(c.moveSet, "")
+            compare(c.moveSetName, "")
+            compare(c.moves.length, 0)
+            compare(c.activeMove, "")
+            verify(!c.moveHolding)
+            // And asking for a move without a set is a no-op rather than a
+            // crash: a set is optional, so every call through it has to be.
+            verify(!c.playMove("jab"))
+            c.stopMove()
+            compare(c.movePoseAt("jab", 0.5), null)
+        }
+
+        function test_the_shipped_set_loads_by_name() {
+            verify(c.shippedMoveSets["martial arts"] !== undefined)
+            c.moveSet = "martial arts"
+            compare(c.moveSetName, "martial arts")
+            // The fourteen of the reference sheet, and the same names the
+            // model publishes.
+            compare(c.moves.length, 14)
+            compare(c.moves[0].name, "stance")
+            let names = []
+            for (let i = 0; i < c.moves.length; ++i)
+                names.push(c.moves[i].name)
+            verify(names.indexOf("roundhouse") >= 0)
+            verify(names.indexOf("knockdown") >= 0)
+            verify(names.indexOf("getUp") >= 0)
+            // Loading is not playing: a set sits there until it is asked for
+            // something.
+            compare(c.activeMove, "")
+            verify(!c.movePlaying)
+        }
+
+        function test_an_unknown_set_leaves_the_character_alone() {
+            c.moveSet = "martial arts"
+            compare(c.moves.length, 14)
+            // The warning it prints is the point of the warning; what is
+            // being checked here is that the character is left usable.
+            c.moveSet = "no such set"
+            compare(c.moves.length, 0)
+            compare(c.moveSetName, "")
+            verify(!c.playMove("jab"))
+        }
+
+        function test_unloading_gives_the_body_back() {
+            c.moveSet = "martial arts"
+            verify(c.playMove("stance"))
+            verify(c.moveHolding)
+            c.moveSet = ""
+            compare(c.moves.length, 0)
+            verify(!c.moveHolding)
+            compare(c.activeMove, "")
+            // The idle pose takes the joints back to standing.
+            wait(400)
+            fuzzyCompare(c.torso.eulerRotation.y, 0, 0.5)
+        }
+
+        function test_a_move_owns_the_body_while_it_runs() {
+            c.moveSet = "martial arts"
+            verify(c.playMove("stance"))
+            compare(c.activeMove, "stance")
+            verify(c.movePlaying)
+            verify(c.moveHolding)
+            // The blade is the whole of what a stance looks like from any
+            // angle, and it lives on the trunk group.
+            wait(300)
+            verify(Math.abs(c.torso.eulerRotation.y) > 10)
+            // A fighting set closes the hands, and it says so through the
+            // same channel the boxing cycle does.
+            compare(c.moveHandPose, "fist")
+            compare(c.actionHandPose, "fist")
+        }
+
+        function test_an_unknown_move_does_nothing() {
+            c.moveSet = "martial arts"
+            verify(c.playMove("stance"))
+            verify(!c.playMove("moonwalk"))
+            compare(c.activeMove, "stance")
+        }
+
+        function test_a_one_shot_hands_back_to_the_stance() {
+            c.moveSet = "martial arts"
+            verify(c.playMove("jab"))
+            compare(c.activeMove, "jab")
+            // Long enough for the jab and the hand-back: the jab is under
+            // half a second at the default effort.
+            tryCompare(c, "activeMove", "stance", 3000)
+            verify(c.movePlaying)
+        }
+
+        function test_the_finished_signal_names_the_move_that_ended() {
+            c.moveSet = "martial arts"
+            _finished.clear()
+            c.playMove("jab")
+            _finished.wait(3000)
+            compare(_finished.signalArguments[0][0], "jab")
+        }
+
+        function test_a_knockdown_stays_on_the_floor() {
+            c.moveSet = "martial arts"
+            verify(c.playMove("knockdown"))
+            // It ends, and having ended it is still holding: the next thing a
+            // knocked-down figure does is get up, and that is another move.
+            tryCompare(c, "movePlaying", false, 4000)
+            verify(c.moveHolding)
+            compare(c.activeMove, "knockdown")
+            // Flat on its back: the whole trunk group is pitched backwards
+            // and the figure has been dropped to the floor.
+            verify(c.torso.eulerRotation.x < -60)
+            verify(c.gaitLift < -0.8 * c.legHeight)
+            // And the idle pose has been kept off it - a knockdown handed to
+            // IdleAnim stands back up within a fifth of a second.
+            wait(400)
+            verify(c.torso.eulerRotation.x < -60)
+        }
+
+        function test_the_get_up_starts_where_the_knockdown_ended() {
+            c.moveSet = "martial arts"
+            const down = c.movePoseAt("knockdown", 1)
+            const up = c.movePoseAt("getUp", 0)
+            verify(down !== null && up !== null)
+            compare(JSON.stringify(up), JSON.stringify(down))
+            // And it ends on its feet.
+            const end = c.movePoseAt("getUp", 1)
+            fuzzyCompare(end.torso[0], 0, 0.001)
+        }
+
+        function test_stopping_a_held_move_releases_the_body() {
+            c.moveSet = "martial arts"
+            c.playMove("knockdown")
+            tryCompare(c, "movePlaying", false, 4000)
+            verify(c.moveHolding)
+            c.stopMove()
+            verify(!c.moveHolding)
+            compare(c.activeMove, "")
+            // The idle pose brings it upright again.
+            tryVerify(function () { return c.torso.eulerRotation.x > -5 }, 2000)
+        }
+
+        function test_a_move_puts_the_activity_back_to_idle() {
+            c.moveSet = "martial arts"
+            c.activity = Character.Activity.Walking
+            verify(c.playMove("stance"))
+            compare(c.activity, Character.Activity.Idle)
+        }
+
+        function test_starting_another_activity_drops_the_move() {
+            c.moveSet = "martial arts"
+            verify(c.playMove("stance"))
+            c.activity = Character.Activity.Walking
+            verify(!c.moveHolding)
+            compare(c.activeMove, "")
+            c.activity = Character.Activity.Idle
+        }
+
+        function test_the_body_travels_over_its_own_feet_and_comes_back() {
+            c.moveSet = "martial arts"
+            const at = c.position
+            verify(c.playMove("step"))
+            // The step carries the whole figure forward of the character's
+            // position and never moves the character itself.
+            tryVerify(function () { return Math.abs(c.bodyDrift) > 0.1 }, 2000)
+            compare(c.position, at)
+            c.stopMove()
+            c.moveSet = ""
+            tryVerify(function () { return Math.abs(c.bodyDrift) < 0.05 }, 2000)
+        }
+
+        function test_the_pose_a_sheet_reads_is_the_pose_that_plays() {
+            c.moveSet = "martial arts"
+            // Pure: asking twice gives the same answer, and asking with
+            // nothing running gives an answer at all.
+            const a = c.movePoseAt("roundhouse", 0.55)
+            const b = c.movePoseAt("roundhouse", 0.55)
+            compare(JSON.stringify(a), JSON.stringify(b))
+            verify(a.rightLeg !== undefined && a.lift !== undefined)
+            // applyMovePose freezes the joints at that phase.
+            c.applyMovePose("roundhouse", 0.55)
+            fuzzyCompare(c.rightLeg.upperLeg.eulerRotation.x, a.rightLeg.upper[0], 0.001)
+            fuzzyCompare(c.torso.eulerRotation.z, a.torso[2], 0.001)
+        }
+
+        function test_effort_changes_the_speed_and_not_the_pose_family() {
+            c.moveSet = "martial arts"
+            c.actionIntensity = 0.0
+            const slow = c.movePoseAt("jab", 0.45)
+            c.actionIntensity = 1.0
+            const fast = c.movePoseAt("jab", 0.45)
+            // Same joint, further out.
+            verify(Math.abs(fast.leftArm.upper[0]) > Math.abs(slow.leftArm.upper[0]))
+            c.actionIntensity = 0.5
+        }
+
+        SignalSpy {
+            id: _finished
+            target: c
+            signalName: "moveFinished"
+        }
+    }
+}


### PR DESCRIPTION
`Character` can now load a set of named moves on demand — `moveSet`, `playMove()`, `stopMove()`, `moves`, `activeMove` — beside the basic animations every character always carries, and the first set is `MartialArts`, the fourteen moves of the sheet on #238.

- `animation/MoveSet.qml` is the replay machinery a set shares: it animates one number, the phase, writes whatever the set's model answers for it, and eases INTO a move out of whatever pose the body was already holding (`blendMs`) rather than cutting to its first frame
- `movesets/martialarts.js` is the model — Qt-free, so `node` checks it. A move is a short list of key frames rather than a curve per joint, so a one-shot returns to the ready stance by construction, effort scales a move by mixing its keys toward that stance, and `knockdown` can END on the floor with `getUp` starting from exactly that frame
- `settle()` puts every standing frame's height on the foot that reaches the floor first, following the leg through its joints in the order the engine applies them; before it, a deep crouch stood a tenth of a leg into the ground
- `bodyDrift` is `gaitLift`'s companion on the other axis: a step or a jump moves the whole body over its own feet and comes back to zero. Nothing here ever writes `position` — moves are in place
- `CharacterEditor` gets a "Moves" section (load a set, play any move, `stop`, and a line saying playing/holding); `demo/Sandbox.qml` binds the same to `J` `,` `.` `V` `B` on the player
- `bench/MoveSheetSandbox.qml` draws the whole set frozen side by side, or one move as a strip of phases

Verified:
- `cmake --build --preset macos` → exit 0
- `ctest --test-dir build --output-on-failure` → 100% tests passed out of 57, exit 0
- `node plugins/clay_character3d/movesets/martialarts.test.js` → 137 passed, 0 failed, exit 0 — covers the first two `Done when` boxes: the fourteen moves exist and are grouped as the sheet groups them, every move starts and ends where the next can pick up, no standing move leaves a foot more than 0.07 leg heights off the floor, and effort is size and speed only
- `qml_character3d_head_qml` → Totals: 73 passed, 0 failed, of which 16 are the new `MoveSet` cases: loading by name, unloading, an unknown set and an unknown move, a one-shot handing back to the stance, `moveFinished`, the knockdown holding the floor against the idle pose, and the activity state machine dropping a move
- `clayrender plugins/clay_character3d/bench/MoveSheetSandbox.qml --size 2600x760 --wait-for 'ready' --out moves.png` → exit 0; all fourteen columns read as their names, in colour and in silhouette — the third `Done when` box, that a set can be loaded and each of its moves triggered
- `12 files changed, 2882 insertions(+), 3 deletions(-)`

Not verified: Windows and WASM (macOS only here); the sandbox's `J` `,` `.` `V` `B` branches were exercised by calling the same functions through `clayrender --eval`, not as key events.

<details><summary>Naming, the two traps that cost a session, and the one test failure that was not this branch</summary>

**Naming.** The issue left it open and noted that "kit" already means something else under `labs/`. A set is *what a character knows* against the basic set's *what a character is*, so: `MoveSet`, `Character.moveSet`, `playMove()`. `FightAnim` is untouched — the boxing loop stays in the basic set, and the martial-arts set ships beside it.

**Trap 1 — how high a round kick can get.** The engine applies `eulerRotation` as Z, then X, then Y, so a leg is swung out to the side *first* and pitched forward *second*. The swing out is therefore also the ceiling: carried 62 degrees out, the foot cannot rise past 28 degrees above the horizontal however hard the hip is pitched, which is why the first "high roundhouse" never got the foot past the belt. A third of a turn out and a pitch well past the vertical puts it at chest height; what makes the kick read as *round* is then the trunk falling away from it and the supporting heel turning.

**Trap 2 — the floor.** Hand-tuned lift constants put five of the fourteen moves through the ground. `settle()` replaced all of them: it computes the drop from the two legs' actual joint angles and stands the figure on whichever foot reaches first. The node suite pins the result at ±0.07 leg heights for every standing move, which is the assertion a screenshot cannot make.

**`testsbx_plugin`.** It failed on the first full run here with `module "Clayground.MyPlugin" plugin "MyPluginplugin" not found`. Cause: `build/bin/sbx_plugin.app/Contents/Resources/qml/Clayground/MyPlugin/` was missing `libMyPluginplugin.dylib` — the app's POST_BUILD copy of `bin/qml` had run against a half-filled directory on the first parallel build, which is the #188 failure the `clay_qml_modules` edge in `cmake/clayapp.cmake` exists to prevent and evidently still lets through for this example's own plugin. Forcing the app to relink re-ran the copy and the test passes; both final runs above are green. Not touched here — it is a build-system bug in `examples/pluginlive`, not in this change.

**Left for later.** The set is not reachable from the performance-script grammar in `scripting/performancescript.js`; root motion (walking a character to where the kick lands) is still the caller's business by design.

</details>

Closes #238
